### PR TITLE
feat: Implement IntoFuture for ApiCall to enable ergonomic .await syntax

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -58,7 +58,9 @@
       "Bash(git restore:*)",
       "Bash(gh milestone:*)",
       "Bash(time cargo test:*)",
-      "Bash(sed:*)"
+      "Bash(sed:*)",
+      "WebFetch(domain:doc.rust-lang.org)",
+      "WebFetch(domain:condacity.io)"
     ],
     "deny": []
   }

--- a/examples/axum-example/tests/common/client.rs
+++ b/examples/axum-example/tests/common/client.rs
@@ -38,7 +38,6 @@ impl TestApp {
         let result = self
             .get("/observations")?
             .with_query(query)
-            .exchange()
             .await?
             .as_json()
             .await?;
@@ -52,7 +51,6 @@ impl TestApp {
         let result = self
             .post("/observations")?
             .json(new_observation)?
-            .exchange()
             .await
             .context("create observation")?
             .as_json()
@@ -70,7 +68,6 @@ impl TestApp {
 
         self.put(path)?
             .json(observation)?
-            .exchange()
             .await
             .context("update observation")?
             .as_empty()
@@ -89,7 +86,6 @@ impl TestApp {
         let result = self
             .patch(call_path)?
             .json(patch)?
-            .exchange()
             .await
             .context("patch observation")?
             .as_json()
@@ -102,7 +98,6 @@ impl TestApp {
         path.add_param("observation_id", ParamValue::new(id));
 
         self.delete(path)?
-            .exchange()
             .await
             .context("delete observation")?
             .as_empty()
@@ -137,7 +132,6 @@ impl TestApp {
             .get("/observations")?
             .with_query(query)
             .with_headers(headers)
-            .exchange()
             .await?
             .as_json()
             .await?;

--- a/examples/axum-example/tests/common/test_app.rs
+++ b/examples/axum-example/tests/common/test_app.rs
@@ -45,7 +45,6 @@ impl TestServer for AppTestServer {
             .expect("valid path")
             .with_description("Check if the API service is healthy and operational")
             .with_expected_status_code(StatusCode::OK)
-            .exchange()
             .await
         else {
             return Ok(HealthStatus::Unhealthy);

--- a/examples/axum-example/tests/error_handling_integration.rs
+++ b/examples/axum-example/tests/error_handling_integration.rs
@@ -18,7 +18,6 @@ async fn test_unexpected_status_code_error(#[future] app: TestApp) -> anyhow::Re
     let result = app
         .get("/nonexistent-endpoint")?
         .with_expected_status(200)
-        .exchange()
         .await;
 
     match result {
@@ -45,11 +44,7 @@ async fn test_unexpected_status_code_error(#[future] app: TestApp) -> anyhow::Re
 async fn test_sucessful_endpoint_bad_status(#[future] app: TestApp) -> anyhow::Result<()> {
     let app = app.await;
 
-    let result = app
-        .get("/observations")?
-        .with_expected_status(201)
-        .exchange()
-        .await;
+    let result = app.get("/observations")?.with_expected_status(201).await;
 
     match result {
         Err(ApiClientError::UnexpectedStatusCode { status_code, body }) => {

--- a/lib/clawspec-core/examples/get.rs
+++ b/lib/clawspec-core/examples/get.rs
@@ -19,7 +19,6 @@ async fn main() -> anyhow::Result<()> {
     // Simple get call with no parameters
     let _result = client
         .get("/breeds/list")?
-        .exchange()
         .await?
         .as_json::<BreedsList>()
         .await?;
@@ -28,12 +27,7 @@ async fn main() -> anyhow::Result<()> {
     let mut path = CallPath::from("/breed/{breed}/images");
     path.add_param("breed", ParamValue::new("hound"));
 
-    let _result = client
-        .get(path)?
-        .exchange()
-        .await?
-        .as_json::<BreedImages>()
-        .await?;
+    let _result = client.get(path)?.await?.as_json::<BreedImages>().await?;
 
     // extract collected data from client
     let paths = client.collected_openapi().await;

--- a/lib/clawspec-core/src/client/collectors.rs
+++ b/lib/clawspec-core/src/client/collectors.rs
@@ -294,7 +294,7 @@ pub(super) struct CalledOperation {
 /// // ✅ CORRECT: Always consume the CallResult
 /// let user: User = client
 ///     .get("/users/123")?
-///     .exchange()
+///     
 ///     .await?
 ///     .as_json()  // ← This is required!
 ///     .await?;
@@ -302,13 +302,13 @@ pub(super) struct CalledOperation {
 /// // ✅ CORRECT: For empty responses (like DELETE)
 /// client
 ///     .delete("/users/123")?
-///     .exchange()
+///     
 ///     .await?
 ///     .as_empty()  // ← This is required!
 ///     .await?;
 ///
 /// // ❌ INCORRECT: This will not generate proper OpenAPI documentation
-/// // let _result = client.get("/users/123")?.exchange().await?;
+/// // let _result = client.get("/users/123")?.await?;
 /// // // Missing .as_json() or other consumption method! This will not generate proper OpenAPI documentation
 /// # Ok(())
 /// # }
@@ -346,7 +346,7 @@ pub struct CallResult {
 /// let mut client = ApiClient::builder().build()?;
 /// let raw_result = client
 ///     .get("/api/data")?
-///     .exchange()
+///     
 ///     .await?
 ///     .as_raw()
 ///     .await?;
@@ -546,7 +546,7 @@ impl CallResult {
     /// let mut client = ApiClient::builder().build()?;
     /// let user: User = client
     ///     .get("/users/123")?
-    ///     .exchange()
+    ///     
     ///     .await?
     ///     .as_json()
     ///     .await?;
@@ -603,7 +603,7 @@ impl CallResult {
     /// let mut client = ApiClient::builder().build()?;
     /// let text = client
     ///     .get("/api/status")?
-    ///     .exchange()
+    ///     
     ///     .await?
     ///     .as_text()
     ///     .await?;
@@ -640,7 +640,7 @@ impl CallResult {
     /// let mut client = ApiClient::builder().build()?;
     /// let bytes = client
     ///     .get("/api/download")?
-    ///     .exchange()
+    ///     
     ///     .await?
     ///     .as_bytes()
     ///     .await?;
@@ -680,7 +680,7 @@ impl CallResult {
     /// let mut client = ApiClient::builder().build()?;
     /// let raw_result = client
     ///     .get("/api/data")?
-    ///     .exchange()
+    ///     
     ///     .await?
     ///     .as_raw()
     ///     .await?;
@@ -730,7 +730,7 @@ impl CallResult {
     ///
     /// client
     ///     .delete("/items/123")?
-    ///     .exchange()
+    ///     
     ///     .await?
     ///     .as_empty()
     ///     .await?;

--- a/lib/clawspec-core/src/client/mod.rs
+++ b/lib/clawspec-core/src/client/mod.rs
@@ -85,7 +85,7 @@ mod output;
 ///     // Make a request and capture the schema
 ///     let user: User = client
 ///         .get("/users/123")?
-///         .exchange()
+///         
 ///         .await?
 ///         .as_json()
 ///         .await?;
@@ -160,7 +160,7 @@ mod output;
 ///     )
 ///     .with_header("Authorization", "Bearer token123")
 ///     .with_expected_status_codes(expected_status_codes!(200, 404))
-///     .exchange()
+///     
 ///     .await?
 ///     .as_json::<Vec<UserData>>()
 ///     .await?;
@@ -170,7 +170,7 @@ mod output;
 ///     .post("/users")?
 ///     .json(&user_data)?
 ///     .with_expected_status_codes(expected_status_codes!(201, 409))
-///     .exchange()
+///     
 ///     .await?
 ///     .as_json::<UserData>()
 ///     .await?;
@@ -221,8 +221,8 @@ mod output;
 /// let user_data = UserData { name: "John".to_string() };
 ///
 /// // Make some API calls...
-/// client.get("/users")?.exchange().await?.as_json::<Vec<UserData>>().await?;
-/// client.post("/users")?.json(&user_data)?.exchange().await?.as_json::<UserData>().await?;
+/// client.get("/users")?.await?.as_json::<Vec<UserData>>().await?;
+/// client.post("/users")?.json(&user_data)?.await?.as_json::<UserData>().await?;
 ///
 /// // Generate OpenAPI specification
 /// let openapi = client.collected_openapi().await;
@@ -244,7 +244,7 @@ mod output;
 /// # async fn example() -> Result<(), ApiClientError> {
 /// let mut client = ApiClient::builder().build()?;
 ///
-/// match client.get("/users/999")?.exchange().await {
+/// match client.get("/users/999")?.await {
 ///     Ok(response) => {
 ///         // Handle successful response
 ///         println!("Success!");
@@ -354,8 +354,8 @@ impl ApiClient {
     /// let user_data = UserData { name: "John".to_string() };
     ///
     /// // Make some API calls to collect data
-    /// client.get("/users")?.exchange().await?.as_json::<Vec<UserData>>().await?;
-    /// client.post("/users")?.json(&user_data)?.exchange().await?.as_json::<UserData>().await?;
+    /// client.get("/users")?.await?.as_json::<Vec<UserData>>().await?;
+    /// client.post("/users")?.json(&user_data)?.await?.as_json::<UserData>().await?;
     ///
     /// // Generate complete OpenAPI specification
     /// let openapi = client.collected_openapi().await;

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -23,11 +23,10 @@
 //!     .with_host("api.example.com")
 //!     .build()?;
 //!
-//! // Make requests - schemas are captured automatically
+//! // Make requests - schemas are captured automatically  
 //! let user: User = client
 //!     .get("/users/123")?
-//!     .exchange()
-//!     .await?
+//!     .await?  // ← Direct await using IntoFuture
 //!     .as_json()  // ← Important: Must consume result for OpenAPI generation!
 //!     .await?;
 //!
@@ -58,7 +57,7 @@
 //!     let mut client = TestClient::start(MyServer).await?;
 //!     
 //!     // Test your API
-//!     let response = client.get("/users")?.exchange().await?.as_json::<serde_json::Value>().await?;
+//!     let response = client.get("/users")?.await?.as_json::<serde_json::Value>().await?;
 //!     
 //!     // Write OpenAPI spec
 //!     client.write_openapi("api.yml").await?;
@@ -85,12 +84,12 @@
 //! let headers = CallHeaders::new()
 //!     .add_header("Authorization", "Bearer token");
 //!
+//! // Direct await with parameters:
 //! let response = client
 //!     .get(path)?
 //!     .with_query(query)
 //!     .with_headers(headers)
-//!     .exchange()
-//!     .await?;
+//!     .await?;  // Direct await using IntoFuture
 //! # Ok(())
 //! # }
 //! ```
@@ -107,13 +106,13 @@
 //! // Single codes
 //! client.post("/users")?
 //!     .with_expected_status_codes(expected_status_codes!(201, 202))
-//!     .exchange()
+//!     
 //!     .await?;
 //!
 //! // Ranges
 //! client.get("/health")?
 //!     .with_expected_status_codes(expected_status_codes!(200-299))
-//!     .exchange()
+//!     
 //!     .await?;
 //! # Ok(())
 //! # }

--- a/lib/clawspec-core/src/test_client/mod.rs
+++ b/lib/clawspec-core/src/test_client/mod.rs
@@ -40,7 +40,7 @@
 //!     
 //!     let response = test_client
 //!         .get("/api/users")?
-//!         .exchange()
+//!         
 //!         .await?;
 //!     
 //!     // Generate OpenAPI documentation
@@ -112,7 +112,7 @@ pub use self::test_server::*;
 /// async fn test_api() -> Result<(), Box<dyn std::error::Error>> {
 ///     let mut client = TestClient::start(MyServer).await?;
 ///     
-///     let response = client.get("/users")?.exchange().await?.as_raw().await?;
+///     let response = client.get("/users")?.await?.as_raw().await?;
 ///     assert_eq!(response.status_code(), http::StatusCode::OK);
 ///     
 ///     Ok(())
@@ -158,7 +158,7 @@ pub use self::test_server::*;
 ///     let mut client = TestClient::start(MyServer).await?;
 ///     
 ///     // Client is already configured with base path /api/v1
-///     let response = client.get("/users")?.exchange().await?; // Calls /api/v1/users
+///     let response = client.get("/users")?.await?; // Calls /api/v1/users
 ///     
 ///     Ok(())
 /// }
@@ -189,9 +189,9 @@ pub use self::test_server::*;
 ///     let mut client = TestClient::start(MyServer).await?;
 ///     
 ///     // Make various API calls
-///     client.get("/users")?.exchange().await?.as_json::<serde_json::Value>().await?;
-///     client.post("/users")?.json(&serde_json::json!({"name": "John"}))?.exchange().await?.as_json::<serde_json::Value>().await?;
-///     client.get("/users/123")?.exchange().await?.as_json::<serde_json::Value>().await?;
+///     client.get("/users")?.await?.as_json::<serde_json::Value>().await?;
+///     client.post("/users")?.json(&serde_json::json!({"name": "John"}))?.await?.as_json::<serde_json::Value>().await?;
+///     client.get("/users/123")?.await?.as_json::<serde_json::Value>().await?;
 ///     
 ///     // Generate OpenAPI specification
 ///     client.write_openapi("docs/openapi.yml").await?;
@@ -223,7 +223,7 @@ pub use self::test_server::*;
 /// let mut client = TestClient::start(MyServer).await?;
 ///
 /// // These are all ApiClient methods available directly on TestClient
-/// let response = client.get("/endpoint")?.exchange().await?.as_json::<serde_json::Value>().await?;
+/// let response = client.get("/endpoint")?.await?.as_json::<serde_json::Value>().await?;
 /// let openapi = client.collected_openapi().await;
 /// client.register_schema::<MyType>().await;
 /// # Ok(())
@@ -348,7 +348,7 @@ where
     ///
     ///     async fn is_healthy(&self, client: &mut ApiClient) -> Result<clawspec_core::test_client::HealthStatus, Self::Error> {
     ///         // Custom health check
-    ///         match client.get("/health").unwrap().exchange().await {
+    ///         match client.get("/health").unwrap().await {
     ///             Ok(_) => Ok(clawspec_core::test_client::HealthStatus::Healthy),
     ///             Err(_) => Ok(clawspec_core::test_client::HealthStatus::Unhealthy),
     ///         }
@@ -556,8 +556,8 @@ where
     ///     let mut client = TestClient::start(MyServer).await?;
     ///     
     ///     // Make some API calls
-    ///     client.get("/users")?.exchange().await?.as_json::<serde_json::Value>().await?;
-    ///     client.post("/users")?.json(&serde_json::json!({"name": "John"}))?.exchange().await?.as_json::<serde_json::Value>().await?;
+    ///     client.get("/users")?.await?.as_json::<serde_json::Value>().await?;
+    ///     client.post("/users")?.json(&serde_json::json!({"name": "John"}))?.await?.as_json::<serde_json::Value>().await?;
     ///     
     ///     // Generate YAML specification
     ///     client.write_openapi("openapi.yml").await?;
@@ -585,7 +585,7 @@ where
     /// let mut client = TestClient::start(MyServer).await?;
     ///
     /// // Make API calls
-    /// client.get("/api/health")?.exchange().await?.as_json::<serde_json::Value>().await?;
+    /// client.get("/api/health")?.await?.as_json::<serde_json::Value>().await?;
     ///
     /// // Write in different formats
     /// client.write_openapi("docs/openapi.yaml").await?;  // YAML format
@@ -685,7 +685,7 @@ impl<T> Drop for TestClient<T> {
     /// {
     ///     let client = TestClient::start(MyServer).await?;
     ///     // Use the client for testing
-    ///     client.get("/api/test")?.exchange().await?.as_json::<serde_json::Value>().await?;
+    ///     client.get("/api/test")?.await?.as_json::<serde_json::Value>().await?;
     /// } // <- TestClient is dropped here, server task is automatically aborted
     ///   
     /// // Server is no longer running

--- a/lib/clawspec-core/src/test_client/test_server.rs
+++ b/lib/clawspec-core/src/test_client/test_server.rs
@@ -61,7 +61,7 @@ use crate::{ApiClient, ApiClientBuilder};
 ///
 ///     async fn is_healthy(&self, client: &mut clawspec_core::ApiClient) -> Result<HealthStatus, Self::Error> {
 ///         // Check if server is ready by making a health check request
-///         match client.get("/health").unwrap().exchange().await {
+///         match client.get("/health").unwrap().await {
 ///             Ok(_) => Ok(HealthStatus::Healthy),
 ///             Err(_) => Ok(HealthStatus::Unhealthy),
 ///         }
@@ -234,7 +234,7 @@ pub trait TestServer {
     ///     # async fn launch(&self, _listener: TcpListener) -> Result<(), Self::Error> { Ok(()) }
     ///     async fn is_healthy(&self, client: &mut ApiClient) -> Result<HealthStatus, Self::Error> {
     ///         // Try to make a health check request
-    ///         match client.get("/health").unwrap().exchange().await {
+    ///         match client.get("/health").unwrap().await {
     ///             Ok(_) => Ok(HealthStatus::Healthy),
     ///             Err(_) => Ok(HealthStatus::Unhealthy),
     ///         }


### PR DESCRIPTION
## Summary

- Implement IntoFuture trait for ApiCall enabling direct `.await` syntax
- Make exchange() method private to enforce new API pattern
- Update all documentation and examples to use new ergonomic syntax
- Preserve all OpenAPI schema collection functionality
- All 281 tests pass with new implementation

## Test plan

- [x] All existing tests pass (281/281)
- [x] IntoFuture implementation verified with type tests
- [x] Documentation examples updated and verified
- [x] Example applications compile and run correctly
- [x] OpenAPI schema collection still works properly

🤖 Generated with [Claude Code](https://claude.ai/code)