### PR TITLE
chore: release v0.1.1

### DIFF
--- a/lib/clawspec-core/CHANGELOG.md
+++ b/lib/clawspec-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ilaborie/clawspec/compare/clawspec-core-v0.1.0...clawspec-core-v0.1.1) - 2025-07-14
+
+### Other
+
+- release v0.1.0 ([#75](https://github.com/ilaborie/clawspec/pull/75))
+
 ## [0.1.0](https://github.com/ilaborie/clawspec/releases/tag/clawspec-core-v0.1.0) - 2025-07-14
 
 ### Added

--- a/lib/clawspec-core/Cargo.toml
+++ b/lib/clawspec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawspec-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Core library for generating OpenAPI specifications from tests"
 license.workspace = true

--- a/lib/clawspec-macro/CHANGELOG.md
+++ b/lib/clawspec-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ilaborie/clawspec/compare/clawspec-macro-v0.1.0...clawspec-macro-v0.1.1) - 2025-07-14
+
+### Other
+
+- release v0.1.0 ([#75](https://github.com/ilaborie/clawspec/pull/75))
+
 ## [0.1.0](https://github.com/ilaborie/clawspec/releases/tag/clawspec-macro-v0.1.0) - 2025-07-14
 
 ### Added

--- a/lib/clawspec-macro/Cargo.toml
+++ b/lib/clawspec-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawspec-macro"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Procedural macros for clawspec OpenAPI generation"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `clawspec-core`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `clawspec-macro`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `clawspec-core`

<blockquote>

## [0.1.1](https://github.com/ilaborie/clawspec/compare/clawspec-core-v0.1.0...clawspec-core-v0.1.1) - 2025-07-14

### Other

- release v0.1.0 ([#75](https://github.com/ilaborie/clawspec/pull/75))
</blockquote>

## `clawspec-macro`

<blockquote>

## [0.1.1](https://github.com/ilaborie/clawspec/compare/clawspec-macro-v0.1.0...clawspec-macro-v0.1.1) - 2025-07-14

### Other

- release v0.1.0 ([#75](https://github.com/ilaborie/clawspec/pull/75))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).