### PR TITLE
feat: Add OpenAPI response descriptions support

### DIFF
--- a/examples/axum-example/doc/openapi.yml
+++ b/examples/axum-example/doc/openapi.yml
@@ -60,7 +60,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: Status code 200
           content:
             application/json:
               schema:
@@ -106,7 +106,7 @@ paths:
               format: binary
       responses:
         '201':
-          description: ''
+          description: Status code 201
           content:
             application/json:
               schema:
@@ -114,13 +114,13 @@ paths:
                 format: int32
                 minimum: 0
         '400':
-          description: ''
+          description: Status code 400
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TestClientError'
         '415':
-          description: ''
+          description: Status code 415
           content:
             application/json:
               schema:
@@ -147,7 +147,7 @@ paths:
                 lng: 45.0
       responses:
         '200':
-          description: ''
+          description: Status code 200
     delete:
       tags:
       - observations
@@ -156,7 +156,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Status code 200
           content:
             application/json:
               schema:
@@ -179,7 +179,7 @@ paths:
               format: binary
       responses:
         '201':
-          description: ''
+          description: Status code 201
           content:
             application/json:
               schema:
@@ -201,7 +201,7 @@ paths:
               format: binary
       responses:
         '201':
-          description: ''
+          description: Status code 201
           content:
             application/json:
               schema:
@@ -232,7 +232,7 @@ paths:
                 lng: 13.5
       responses:
         '200':
-          description: ''
+          description: Status code 200
     delete:
       tags:
       - observations
@@ -246,7 +246,7 @@ paths:
           $ref: '#/components/schemas/ObservationId'
       responses:
         '200':
-          description: ''
+          description: Status code 200
           content:
             application/json: {}
     patch:
@@ -272,7 +272,7 @@ paths:
               position: null
       responses:
         '200':
-          description: ''
+          description: Status code 200
           content:
             application/json:
               schema:

--- a/lib/clawspec-core/src/client/collectors.rs
+++ b/lib/clawspec-core/src/client/collectors.rs
@@ -255,6 +255,7 @@ pub(super) struct CalledOperation {
     path: String,
     operation: Operation,
     result: Option<CallResult>,
+    response_description: Option<String>,
 }
 
 /// Represents the result of an API call with response processing capabilities.
@@ -526,15 +527,23 @@ impl CallResult {
             });
         };
 
+        // Get response description from the operation, if available
+        let status_code = self.status.as_u16();
+        let description = operation
+            .response_description
+            .clone()
+            .unwrap_or_else(|| format!("Status code {status_code}"));
+
         let response = if let Some(content_type) = &self.content_type {
             // Create content
             let content = Content::builder().schema(schema).build();
             ResponseBuilder::new()
+                .description(description)
                 .content(content_type.to_string(), content)
                 .build()
         } else {
             // Empty response
-            ResponseBuilder::new().build()
+            ResponseBuilder::new().description(description).build()
         };
 
         operation
@@ -786,6 +795,7 @@ impl CalledOperation {
         request_body: Option<&CallBody>,
         tags: Option<Vec<String>>,
         description: Option<String>,
+        response_description: Option<String>,
         // TODO cookie - https://github.com/ilaborie/clawspec/issues/18
     ) -> Self {
         // Build parameters
@@ -846,6 +856,7 @@ impl CalledOperation {
             path: path_name.to_string(),
             operation,
             result: None,
+            response_description,
         }
     }
 

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -118,6 +118,27 @@
 //! # }
 //! ```
 //!
+//! ## Response Descriptions
+//!
+//! Add descriptive text to your OpenAPI responses for better documentation:
+//!
+//! ```rust
+//! use clawspec_core::ApiClient;
+//!
+//! # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
+//! // Set a description for the actual returned status code
+//! client.get("/users/{id}")?
+//!     .with_response_description("User details if found, or error information")
+//!     .await?;
+//!
+//! // The description applies to whatever status code is actually returned
+//! client.post("/users")?
+//!     .with_response_description("User created successfully or validation error")
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## Schema Registration
 //!
 //! ```rust


### PR DESCRIPTION
## Summary

This PR implements OpenAPI response descriptions support, addressing issue #83. The feature allows developers to add descriptive text to OpenAPI responses for better API documentation.

## Key Features

- **Simple API**: Single method `with_response_description(description)` that applies to the actual returned status code
- **Intuitive**: No need to predict status codes upfront - description applies to whatever status code is actually returned
- **Method Chaining**: Seamless integration with existing fluent API patterns
- **Automatic Fallback**: Default descriptions like "Status code 200" when no custom description is provided
- **Fully Tested**: Comprehensive unit tests covering all functionality

## Usage Example

```rust
use clawspec_core::ApiClient;

// Set a description for the actual returned status code
let user = client
    .get("/users/{id}")?
    .with_response_description("User details if found, or error information")
    .await?
    .as_json::<User>()
    .await?;

// The description applies to whatever status code is actually returned
let new_user = client
    .post("/users")?
    .with_response_description("User created successfully or validation error")
    .await?
    .as_json::<User>()
    .await?;
```

## Generated OpenAPI Output

Before:
```yaml
responses:
  '200':
    description: ''  # Empty description
    content:
      application/json:
        schema:
          $ref: '#/components/schemas/User'
```

After:
```yaml
responses:
  '200':
    description: 'User details if found, or error information'
    content:
      application/json:
        schema:
          $ref: '#/components/schemas/User'
```

## Implementation Details

- **Data Structure**: Uses `Option<String>` to store response description
- **Application**: Description is applied during OpenAPI generation based on actual response status code
- **Fallback**: Automatically generates default descriptions when none provided
- **Integration**: Works seamlessly with all existing response processing methods

## Testing

- ✅ All 287 tests pass
- ✅ 3 new comprehensive unit tests for response descriptions
- ✅ Code formatting and linting checks pass
- ✅ Documentation tests pass
- ✅ Integration tests verify OpenAPI generation

## Documentation Updates

- Updated crate-level documentation with response descriptions section
- Added comprehensive method documentation with examples
- Updated ApiCall struct documentation to include new functionality

## Breaking Changes

None. This is a purely additive feature that maintains full backward compatibility.

## Closes

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)