### PR TITLE
docs: add comprehensive tutorial module for clawspec-core

### DIFF
--- a/lib/clawspec-core/src/_tutorial/chapter_0.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_0.rs
@@ -1,0 +1,78 @@
+//! # Chapter 0: Introduction
+//!
+//! Welcome to Clawspec! This chapter explains what Clawspec is and why you might want to use it.
+//!
+//! ## What is Clawspec?
+//!
+//! Clawspec is a Rust library that generates OpenAPI specifications from your HTTP client test code.
+//! Instead of writing OpenAPI specifications by hand or using code annotations, you write tests
+//! that exercise your API, and Clawspec captures the request/response patterns to generate
+//! accurate documentation.
+//!
+//! ## The Test-Driven Documentation Approach
+//!
+//! Traditional approaches to OpenAPI documentation have drawbacks:
+//!
+//! | Approach | Drawback |
+//! |----------|----------|
+//! | Manual YAML/JSON | Tedious, error-prone, often out of sync with actual API |
+//! | Code annotations | Clutters source code, still requires manual maintenance |
+//! | Code generation | Generated specs may not reflect actual runtime behavior |
+//!
+//! Clawspec takes a different approach: **your tests become your documentation source**.
+//!
+//! Benefits:
+//! - **Always accurate**: Documentation is generated from actual API calls
+//! - **Test coverage = doc coverage**: If it's tested, it's documented
+//! - **Type-safe**: Rust's type system ensures schema correctness
+//! - **No code clutter**: Your production code stays clean
+//!
+//! ## How It Works
+//!
+//! 1. **Write tests** that make HTTP requests to your API
+//! 2. **Use typed responses** with `#[derive(ToSchema)]` for automatic schema capture
+//! 3. **Generate OpenAPI** from the collected request/response data
+//!
+//! ```text
+//! ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+//! │  Test Code  │ ──► │  ApiClient  │ ──► │   OpenAPI   │
+//! │             │     │  (captures) │     │    Spec     │
+//! └─────────────┘     └─────────────┘     └─────────────┘
+//! ```
+//!
+//! ## Prerequisites
+//!
+//! To follow this tutorial, you should be familiar with:
+//!
+//! - Rust basics (structs, traits, async/await)
+//! - HTTP concepts (methods, status codes, JSON)
+//! - Basic understanding of OpenAPI (helpful but not required)
+//!
+//! ## Dependencies
+//!
+//! Add these to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! clawspec-core = "0.2"
+//! serde = { version = "1", features = ["derive"] }
+//! utoipa = { version = "5", features = ["preserve_order"] }
+//! tokio = { version = "1", features = ["full"] }
+//!
+//! [dev-dependencies]
+//! tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+//! ```
+//!
+//! ## What You'll Learn
+//!
+//! By the end of this tutorial, you'll know how to:
+//!
+//! - Create and configure an API client
+//! - Make GET, POST, PUT, PATCH, and DELETE requests
+//! - Use path, query, header, and cookie parameters
+//! - Handle different response types and errors
+//! - Customize OpenAPI output with tags and descriptions
+//! - Use redaction for stable documentation examples
+//! - Integrate with test frameworks using `TestClient`
+//!
+//! Ready to start? Continue to [Chapter 1: Getting Started][super::chapter_1]!

--- a/lib/clawspec-core/src/_tutorial/chapter_1.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_1.rs
@@ -1,0 +1,133 @@
+//! # Chapter 1: Getting Started
+//!
+//! In this chapter, you'll learn how to create an API client and make your first request.
+//!
+//! ## Creating the Client
+//!
+//! The [`ApiClient`][crate::ApiClient] is your main entry point for making requests.
+//! Use the builder pattern to configure it:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Minimal client (connects to localhost:80)
+//! let client = ApiClient::builder().build()?;
+//!
+//! // Client with custom host
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .build()?;
+//!
+//! // Client with host and port
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_port(8080)
+//!     .build()?;
+//!
+//! // Client with base path (all requests will be prefixed)
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_base_path("/api/v1")?
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Your First GET Request
+//!
+//! Let's make a simple GET request. You'll need a response type that implements
+//! [`Deserialize`][serde::Deserialize] and [`ToSchema`][utoipa::ToSchema]:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use serde::Deserialize;
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User {
+//!     id: u64,
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .build()?;
+//!
+//! // Make a GET request
+//! let user: User = client
+//!     .get("/users/123")?   // Create the request
+//!     .await?               // Send it (using IntoFuture)
+//!     .as_json()            // Parse response as JSON
+//!     .await?;
+//!
+//! println!("Got user: {} ({})", user.name, user.email);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Understanding the Flow
+//!
+//! Let's break down what happens:
+//!
+//! 1. **`client.get("/users/123")?`** - Creates an [`ApiCall`][crate::ApiCall] builder
+//! 2. **`.await?`** - Sends the request (via [`IntoFuture`])
+//! 3. **`.as_json().await?`** - Parses the response body as JSON
+//!
+//! The schema for `User` is automatically captured when you call `.as_json()`.
+//!
+//! ## Generating the OpenAPI Spec
+//!
+//! After making requests, you can generate the OpenAPI specification:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder().build()?;
+//!
+//! // ... make some requests ...
+//!
+//! // Get the collected OpenAPI spec
+//! let openapi = client.collected_openapi().await;
+//!
+//! // Output as YAML
+//! println!("{}", openapi.to_yaml()?);
+//!
+//! // Or as JSON
+//! println!("{}", openapi.to_pretty_json()?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Response Without Parsing
+//!
+//! Sometimes you don't need to parse the response body:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Get raw response details
+//! let raw = client.get("/health")?.await?.as_raw().await?;
+//! println!("Status: {}", raw.status_code());
+//! println!("Body: {:?}", raw.text());
+//!
+//! // Or just consume the response without reading the body
+//! client.get("/ping")?.await?.as_empty().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Use [`ApiClient::builder()`][crate::ApiClient::builder] to create clients
+//! - Response types need `#[derive(Deserialize, ToSchema)]`
+//! - Call `.as_json()` to parse responses and capture schemas
+//! - Use `collected_openapi()` to get the generated spec
+//!
+//! Next: [Chapter 2: Request Building][super::chapter_2] - Learn about POST requests and parameters.

--- a/lib/clawspec-core/src/_tutorial/chapter_2.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_2.rs
@@ -1,0 +1,196 @@
+//! # Chapter 2: Request Building
+//!
+//! This chapter covers building more complex requests with POST, path parameters,
+//! and query parameters.
+//!
+//! ## POST Requests with JSON Body
+//!
+//! To send JSON data, use the `.json()` method. Your request type needs
+//! [`Serialize`][serde::Serialize] and [`ToSchema`][utoipa::ToSchema]:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use serde::{Deserialize, Serialize};
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, ToSchema)]
+//! struct CreateUser {
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User {
+//!     id: u64,
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .build()?;
+//!
+//! let new_user = CreateUser {
+//!     name: "Alice".to_string(),
+//!     email: "alice@example.com".to_string(),
+//! };
+//!
+//! let created: User = client
+//!     .post("/users")?
+//!     .json(&new_user)?     // Serialize as JSON
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//!
+//! println!("Created user with ID: {}", created.id);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Both request and response schemas are captured automatically.
+//!
+//! ## Path Parameters
+//!
+//! Use [`CallPath`][crate::CallPath] for templated paths with parameters:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallPath, ParamValue};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct User { id: u64 }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Define path with parameter placeholder
+//! let path = CallPath::from("/users/{user_id}")
+//!     .add_param("user_id", ParamValue::new(123));
+//!
+//! let user: User = client
+//!     .get(path)?
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The generated OpenAPI will show `/users/{user_id}` with the parameter documented.
+//!
+//! ## Query Parameters
+//!
+//! Use [`CallQuery`][crate::CallQuery] for query string parameters:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallQuery};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct UserList { users: Vec<String> }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let query = CallQuery::new()
+//!     .add_param("page", 1)
+//!     .add_param("limit", 20)
+//!     .add_param("sort", "name");
+//!
+//! let users: UserList = client
+//!     .get("/users")?
+//!     .with_query(query)
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! This generates a request to `/users?page=1&limit=20&sort=name`.
+//!
+//! ## Combining Path and Query Parameters
+//!
+//! You can use both together:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallPath, CallQuery, ParamValue};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Posts { posts: Vec<String> }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let path = CallPath::from("/users/{user_id}/posts")
+//!     .add_param("user_id", ParamValue::new(42));
+//!
+//! let query = CallQuery::new()
+//!     .add_param("status", "published")
+//!     .add_param("limit", 10);
+//!
+//! let posts: Posts = client
+//!     .get(path)?
+//!     .with_query(query)
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Other HTTP Methods
+//!
+//! All standard HTTP methods are supported:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallPath, ParamValue};
+//! # use serde::{Serialize, Deserialize};
+//! # use utoipa::ToSchema;
+//! # #[derive(Serialize, ToSchema)]
+//! # struct UpdateUser { name: String }
+//! # #[derive(Serialize, ToSchema)]
+//! # struct PatchUser { name: Option<String> }
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct User { id: u64 }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let path = CallPath::from("/users/{id}").add_param("id", ParamValue::new(1));
+//!
+//! // PUT - Full replacement
+//! client.put(path.clone())?
+//!     .json(&UpdateUser { name: "Bob".to_string() })?
+//!     .await?
+//!     .as_empty()
+//!     .await?;
+//!
+//! // PATCH - Partial update
+//! let updated: User = client.patch(path.clone())?
+//!     .json(&PatchUser { name: Some("Robert".to_string()) })?
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//!
+//! // DELETE
+//! client.delete(path)?
+//!     .await?
+//!     .as_empty()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Use `.json(&data)?` to send JSON request bodies
+//! - [`CallPath`][crate::CallPath] handles path parameters like `/users/{id}`
+//! - [`CallQuery`][crate::CallQuery] handles query parameters
+//! - All HTTP methods are available: `get`, `post`, `put`, `patch`, `delete`
+//!
+//! Next: [Chapter 3: Response Handling][super::chapter_3] - Learn about different
+//! response handling strategies.

--- a/lib/clawspec-core/src/_tutorial/chapter_3.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_3.rs
@@ -1,0 +1,233 @@
+//! # Chapter 3: Response Handling
+//!
+//! This chapter covers the various ways to handle API responses, including
+//! error handling patterns.
+//!
+//! ## Response Methods Overview
+//!
+//! After sending a request, you have several options for handling the response:
+//!
+//! | Method | Returns | Use Case |
+//! |--------|---------|----------|
+//! | `as_json::<T>()` | `T` | Standard JSON response |
+//! | `as_optional_json::<T>()` | `Option<T>` | Resource that may not exist (404 → None) |
+//! | `as_result_json::<T, E>()` | `Result<T, E>` | API with typed error responses |
+//! | `as_result_option_json::<T, E>()` | `Result<Option<T>, E>` | Combined: 404 → Ok(None), errors → Err |
+//! | `as_raw()` | `RawResult` | Access status code and raw body |
+//! | `as_empty()` | `()` | Responses with no body (204, etc.) |
+//! | `as_text()` | `String` | Plain text responses |
+//!
+//! ## Standard JSON Response
+//!
+//! The most common pattern - parse JSON and fail on errors:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct User { id: u64 }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let user: User = client
+//!     .get("/users/123")?
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Optional JSON (404 as None)
+//!
+//! Use `as_optional_json()` when a resource might not exist:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct User { id: u64, name: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let user: Option<User> = client
+//!     .get("/users/999")?
+//!     .add_expected_status(404)  // Tell client 404 is expected
+//!     .await?
+//!     .as_optional_json()
+//!     .await?;
+//!
+//! match user {
+//!     Some(u) => println!("Found: {}", u.name),
+//!     None => println!("User not found"),
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Result JSON (Typed Errors)
+//!
+//! When your API returns structured error responses:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Debug, Deserialize, ToSchema)]
+//! # struct User { id: u64 }
+//! #[derive(Debug, Deserialize, ToSchema)]
+//! struct ApiError {
+//!     code: String,
+//!     message: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let result: Result<User, ApiError> = client
+//!     .get("/users/123")?
+//!     .add_expected_status(404)
+//!     .await?
+//!     .as_result_json()
+//!     .await?;
+//!
+//! match result {
+//!     Ok(user) => println!("Got user: {:?}", user),
+//!     Err(error) => println!("API error: {} - {}", error.code, error.message),
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Result Option JSON (404 as Ok(None))
+//!
+//! Combines optional resources with typed errors:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Debug, Deserialize, ToSchema)]
+//! # struct User { id: u64, name: String }
+//! # #[derive(Debug, Deserialize, ToSchema)]
+//! # struct ApiError { message: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // 2xx → Ok(Some(T))
+//! // 404 → Ok(None)
+//! // Other 4xx/5xx → Err(E)
+//! let result: Result<Option<User>, ApiError> = client
+//!     .get("/users/maybe-exists")?
+//!     .add_expected_status(404)
+//!     .await?
+//!     .as_result_option_json()
+//!     .await?;
+//!
+//! match result {
+//!     Ok(Some(user)) => println!("Found: {}", user.name),
+//!     Ok(None) => println!("Not found (but not an error)"),
+//!     Err(e) => println!("Actual error: {}", e.message),
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Expected Status Codes
+//!
+//! By default, Clawspec expects 2xx-4xx status codes. Use these methods to
+//! customize expectations:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, expected_status_codes};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct User { id: u64 }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Add a single expected status
+//! client.get("/users/123")?
+//!     .add_expected_status(404)
+//!     .await?;
+//!
+//! // Use specific status code
+//! client.post("/users")?
+//!     .with_expected_status(201)
+//!     .await?;
+//!
+//! // Use the macro for complex patterns
+//! client.get("/resource")?
+//!     .with_expected_status_codes(expected_status_codes!(200, 201, 204))
+//!     .await?;
+//!
+//! // Ranges are supported
+//! client.get("/resource")?
+//!     .with_expected_status_codes(expected_status_codes!(200-299, 404))
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Raw Response Access
+//!
+//! When you need full control over the response:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let client = ApiClient::builder().build()?;
+//! let raw = client
+//!     .get("/health")?
+//!     .await?
+//!     .as_raw()
+//!     .await?;
+//!
+//! println!("Status: {}", raw.status_code());
+//! println!("Body: {:?}", raw.text());
+//!
+//! // Access as bytes
+//! let bytes: Option<&[u8]> = raw.bytes();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Error Handling
+//!
+//! Clawspec uses [`ApiClientError`][crate::ApiClientError] for client-level errors:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, ApiClientError};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let client = ApiClient::builder().build()?;
+//! match client.get("/users/123")?.with_expected_status(200).await {
+//!     Ok(response) => {
+//!         // Handle success
+//!     }
+//!     Err(ApiClientError::UnexpectedStatusCode { status_code, body }) => {
+//!         println!("Got status {}: {}", status_code, body);
+//!     }
+//!     Err(e) => {
+//!         println!("Other error: {}", e);
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Choose the response method that matches your API's behavior
+//! - Use `add_expected_status()` to tell Clawspec about expected non-2xx codes
+//! - `as_optional_json()` is great for "get or not found" patterns
+//! - `as_result_json()` captures typed error schemas in OpenAPI
+//!
+//! Next: [Chapter 4: Advanced Parameters][super::chapter_4] - Headers, cookies,
+//! and parameter styles.

--- a/lib/clawspec-core/src/_tutorial/chapter_4.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_4.rs
@@ -1,0 +1,234 @@
+//! # Chapter 4: Advanced Parameters
+//!
+//! This chapter covers headers, cookies, and advanced parameter serialization styles.
+//!
+//! ## Header Parameters
+//!
+//! Use [`CallHeaders`][crate::CallHeaders] to add request headers:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallHeaders};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Response { data: String }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let headers = CallHeaders::new()
+//!     .add_header("X-Request-ID", "req-12345")
+//!     .add_header("X-Client-Version", "1.0.0")
+//!     .add_header("Accept-Language", "en-US");
+//!
+//! let response: Response = client
+//!     .get("/data")?
+//!     .with_headers(headers)
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Headers are documented in the OpenAPI specification as header parameters.
+//!
+//! ## Cookie Parameters
+//!
+//! Use [`CallCookies`][crate::CallCookies] for cookie-based parameters:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, CallCookies};
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Profile { name: String }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let cookies = CallCookies::new()
+//!     .add_cookie("session_id", "abc123")
+//!     .add_cookie("user_id", 42)
+//!     .add_cookie("preferences", vec!["dark_mode", "compact"]);
+//!
+//! let profile: Profile = client
+//!     .get("/profile")?
+//!     .with_cookies(cookies)
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Authentication
+//!
+//! Clawspec supports several authentication methods:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, Authentication};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Bearer token (most common for APIs)
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_authentication(Authentication::Bearer("your-api-token".into()))
+//!     .build()?;
+//!
+//! // Basic authentication
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_authentication(Authentication::Basic {
+//!         username: "user".to_string(),
+//!         password: "secret".into(),
+//!     })
+//!     .build()?;
+//!
+//! // API key in header
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_authentication(Authentication::ApiKey {
+//!         header_name: "X-API-Key".to_string(),
+//!         key: "your-api-key".into(),
+//!     })
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can override authentication per-request:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::{ApiClient, Authentication};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_authentication(Authentication::Bearer("default-token".into()))
+//!     .build()?;
+//!
+//! // Use different auth for admin endpoints
+//! client.get("/admin/users")?
+//!     .with_authentication(Authentication::Bearer("admin-token".into()))
+//!     .await?;
+//!
+//! // Remove auth for public endpoints
+//! client.get("/public/status")?
+//!     .with_authentication_none()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Parameter Styles
+//!
+//! OpenAPI defines various serialization styles for parameters. Use [`ParamStyle`][crate::ParamStyle]:
+//!
+//! ### Path Parameter Styles
+//!
+//! ```rust
+//! use clawspec_core::{CallPath, ParamValue, ParamStyle};
+//!
+//! // Simple (default): /users/123
+//! let path = CallPath::from("/users/{id}")
+//!     .add_param("id", ParamValue::new(123));
+//!
+//! // Label style: /users/.123
+//! let path = CallPath::from("/users/{id}")
+//!     .add_param("id", ParamValue::with_style(123, ParamStyle::Label));
+//!
+//! // Matrix style: /users/;id=123
+//! let path = CallPath::from("/users/{id}")
+//!     .add_param("id", ParamValue::with_style(123, ParamStyle::Matrix));
+//! ```
+//!
+//! ### Query Parameter Styles
+//!
+//! ```rust
+//! use clawspec_core::{CallQuery, ParamValue, ParamStyle};
+//!
+//! let tags = vec!["rust", "web", "api"];
+//!
+//! // Form (default): ?tags=rust&tags=web&tags=api
+//! let query = CallQuery::new()
+//!     .add_param("tags", ParamValue::new(tags.clone()));
+//!
+//! // Space delimited: ?tags=rust%20web%20api
+//! let query = CallQuery::new()
+//!     .add_param("tags", ParamValue::with_style(tags.clone(), ParamStyle::SpaceDelimited));
+//!
+//! // Pipe delimited: ?tags=rust|web|api
+//! let query = CallQuery::new()
+//!     .add_param("tags", ParamValue::with_style(tags, ParamStyle::PipeDelimited));
+//! ```
+//!
+//! ### Deep Object Style
+//!
+//! For nested objects in query parameters:
+//!
+//! ```rust
+//! use clawspec_core::{CallQuery, ParamValue, ParamStyle};
+//!
+//! // Deep object: ?filter[status]=active&filter[type]=premium
+//! let filter = serde_json::json!({
+//!     "status": "active",
+//!     "type": "premium"
+//! });
+//!
+//! let query = CallQuery::new()
+//!     .add_param("filter", ParamValue::with_style(filter, ParamStyle::DeepObject));
+//! ```
+//!
+//! ## Alternative Content Types
+//!
+//! Besides JSON, you can send other content types:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use headers::ContentType;
+//! # use serde::Serialize;
+//! # use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, ToSchema)]
+//! struct FormData {
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Form-encoded data
+//! let data = FormData {
+//!     name: "Alice".to_string(),
+//!     email: "alice@example.com".to_string(),
+//! };
+//! client.post("/form")?.form(&data)?.await?;
+//!
+//! // Raw bytes with custom content type
+//! let xml = r#"<user><name>Alice</name></user>"#;
+//! client.post("/xml")?
+//!     .raw(xml.as_bytes().to_vec(), ContentType::xml())
+//!     .await?;
+//!
+//! // Multipart form data
+//! let files = vec![
+//!     ("file1", r#"{"data": "content1"}"#),
+//!     ("file2", r#"{"data": "content2"}"#),
+//! ];
+//! client.post("/upload")?.multipart(files).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - [`CallHeaders`][crate::CallHeaders] and [`CallCookies`][crate::CallCookies] add
+//!   documented parameters
+//! - Authentication can be set at client or request level
+//! - Parameter styles control OpenAPI serialization documentation
+//! - Multiple content types are supported (JSON, form, XML, multipart)
+//!
+//! Next: [Chapter 5: OpenAPI Customization][super::chapter_5] - Tags, descriptions,
+//! and metadata.

--- a/lib/clawspec-core/src/_tutorial/chapter_5.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_5.rs
@@ -1,0 +1,248 @@
+//! # Chapter 5: OpenAPI Customization
+//!
+//! This chapter covers how to customize the generated OpenAPI specification with
+//! tags, descriptions, and metadata.
+//!
+//! ## Adding Operation Tags
+//!
+//! Tags help organize operations in the generated documentation:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Single tag
+//! client.get("/users")?
+//!     .with_tag("users")
+//!     .await?;
+//!
+//! // Multiple tags
+//! client.post("/admin/users")?
+//!     .with_tags(["users", "admin"])
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Tags appear in the OpenAPI spec and are used by documentation tools to group
+//! related endpoints.
+//!
+//! ## Operation Descriptions
+//!
+//! Add descriptions to document what operations do:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! client.get("/users")?
+//!     .with_tag("users")
+//!     .with_description("List all users with optional pagination")
+//!     .await?;
+//!
+//! client.post("/users")?
+//!     .with_tag("users")
+//!     .with_description("Create a new user account")
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Response Descriptions
+//!
+//! Document what responses mean:
+//!
+//! ```rust,no_run
+//! # use clawspec_core::ApiClient;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! client.get("/users/123")?
+//!     .with_response_description("User details or 404 if not found")
+//!     .await?;
+//!
+//! client.post("/users")?
+//!     .with_response_description("The newly created user with generated ID")
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## API Info Configuration
+//!
+//! Configure the API's metadata when building the client:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use utoipa::openapi::{ContactBuilder, InfoBuilder, LicenseBuilder};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let info = InfoBuilder::new()
+//!     .title("My API")
+//!     .version("1.0.0")
+//!     .description(Some("A comprehensive REST API for managing resources"))
+//!     .contact(Some(
+//!         ContactBuilder::new()
+//!             .name(Some("API Support"))
+//!             .email(Some("support@example.com"))
+//!             .url(Some("https://example.com/support"))
+//!             .build(),
+//!     ))
+//!     .license(Some(
+//!         LicenseBuilder::new()
+//!             .name("MIT")
+//!             .url(Some("https://opensource.org/licenses/MIT"))
+//!             .build(),
+//!     ))
+//!     .build();
+//!
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_info(info)
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Server Configuration
+//!
+//! Define servers in the OpenAPI spec:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use utoipa::openapi::ServerBuilder;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .add_server(
+//!         ServerBuilder::new()
+//!             .url("https://api.example.com")
+//!             .description(Some("Production server"))
+//!             .build(),
+//!     )
+//!     .add_server(
+//!         ServerBuilder::new()
+//!             .url("https://staging-api.example.com")
+//!             .description(Some("Staging server"))
+//!             .build(),
+//!     )
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Manual Schema Registration
+//!
+//! Sometimes you need to register schemas that aren't automatically captured:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, register_schemas};
+//! use serde::{Deserialize, Serialize};
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, Deserialize, ToSchema)]
+//! struct Address {
+//!     street: String,
+//!     city: String,
+//!     country: String,
+//! }
+//!
+//! #[derive(Serialize, Deserialize, ToSchema)]
+//! struct User {
+//!     id: u64,
+//!     name: String,
+//!     address: Address,  // Nested schema
+//! }
+//!
+//! #[derive(Serialize, Deserialize, ToSchema)]
+//! struct ApiError {
+//!     code: String,
+//!     message: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder().build()?;
+//!
+//! // Register nested schemas and error types
+//! register_schemas!(client, User, Address, ApiError).await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! This is particularly useful for:
+//! - Nested schemas that might not be fully resolved
+//! - Error response types
+//! - Schemas used in headers or other non-body locations
+//!
+//! ## Combining Everything
+//!
+//! Here's a complete example with all customizations:
+//!
+//! ```rust,no_run
+//! use clawspec_core::{ApiClient, register_schemas};
+//! use utoipa::openapi::{ContactBuilder, InfoBuilder, ServerBuilder};
+//! use serde::{Deserialize, Serialize};
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, ToSchema)]
+//! struct CreateUser { name: String }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User { id: u64, name: String }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct ApiError { code: String, message: String }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Configure client with full metadata
+//! let info = InfoBuilder::new()
+//!     .title("User Management API")
+//!     .version("2.0.0")
+//!     .description(Some("API for managing user accounts"))
+//!     .build();
+//!
+//! let mut client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .with_info(info)
+//!     .add_server(
+//!         ServerBuilder::new()
+//!             .url("https://api.example.com/v2")
+//!             .description(Some("Production"))
+//!             .build(),
+//!     )
+//!     .build()?;
+//!
+//! // Register error schema
+//! register_schemas!(client, ApiError).await;
+//!
+//! // Make requests with full documentation
+//! let user: User = client.post("/users")?
+//!     .json(&CreateUser { name: "Alice".to_string() })?
+//!     .with_tag("users")
+//!     .with_description("Create a new user account")
+//!     .with_response_description("The created user with assigned ID")
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//!
+//! // Generate the OpenAPI spec
+//! let spec = client.collected_openapi().await;
+//! println!("{}", spec.to_yaml()?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Use `.with_tag()` and `.with_tags()` to organize operations
+//! - Use `.with_description()` to document operations
+//! - Configure API info and servers at the client builder level
+//! - Use `register_schemas!` for nested or error schemas
+//!
+//! Next: [Chapter 6: Redaction][super::chapter_6] - Creating stable examples with
+//! dynamic value redaction.

--- a/lib/clawspec-core/src/_tutorial/chapter_6.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_6.rs
@@ -1,0 +1,288 @@
+//! # Chapter 6: Redaction
+//!
+//! This chapter covers the redaction feature for creating stable OpenAPI examples.
+//!
+//! > **Note:** This feature requires the `redaction` feature flag:
+//! > ```toml
+//! > clawspec-core = { version = "0.2", features = ["redaction"] }
+//! > ```
+//!
+//! ## The Problem with Dynamic Values
+//!
+//! When generating OpenAPI examples from real API responses, dynamic values like
+//! UUIDs, timestamps, and tokens change with every test run:
+//!
+//! ```json
+//! {
+//!   "id": "550e8400-e29b-41d4-a716-446655440000",
+//!   "created_at": "2024-03-15T10:30:45.123Z",
+//!   "session_token": "eyJhbGciOiJIUzI1NiIs..."
+//! }
+//! ```
+//!
+//! This causes problems:
+//! - **Snapshot tests fail** because examples change each run
+//! - **Documentation is inconsistent** across builds
+//! - **Sensitive values** might leak into docs
+//!
+//! ## Solution: Redaction
+//!
+//! Redaction lets you replace dynamic values with stable placeholders in OpenAPI
+//! examples while preserving the real values for your test assertions.
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! use clawspec_core::ApiClient;
+//! use serde::Deserialize;
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User {
+//!     id: String,
+//!     name: String,
+//!     created_at: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! // Use as_json_redacted instead of as_json
+//! let result = client
+//!     .post("/users")?
+//!     .json(&serde_json::json!({"name": "Alice"}))?
+//!     .await?
+//!     .as_json_redacted::<User>()
+//!     .await?
+//!     // Replace dynamic values with stable placeholders
+//!     .redact_replace("/id", "00000000-0000-0000-0000-000000000001")?
+//!     .redact_replace("/created_at", "2024-01-01T00:00:00Z")?
+//!     .finish()
+//!     .await;
+//!
+//! // result.value has the REAL dynamic values for assertions
+//! let user = result.value;
+//! assert!(!user.id.is_empty());
+//! assert!(!user.created_at.is_empty());
+//!
+//! // result.redacted has the STABLE values for OpenAPI
+//! let redacted = result.redacted;
+//! assert_eq!(redacted["id"], "00000000-0000-0000-0000-000000000001");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Redaction Operations
+//!
+//! ### Replace Values
+//!
+//! Use `redact_replace` to substitute a value:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Response { token: String, timestamp: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let result = client.post("/auth")?
+//!     .json(&serde_json::json!({"user": "alice"}))?
+//!     .await?
+//!     .as_json_redacted::<Response>()
+//!     .await?
+//!     .redact_replace("/token", "[REDACTED]")?
+//!     .redact_replace("/timestamp", "2024-01-01T00:00:00Z")?
+//!     .finish()
+//!     .await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Remove Values
+//!
+//! Use `redact_remove` to exclude a field entirely:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Response { public_id: String, internal_ref: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let result = client.get("/data")?
+//!     .await?
+//!     .as_json_redacted::<Response>()
+//!     .await?
+//!     .redact_replace("/public_id", "id-001")?
+//!     .redact_remove("/internal_ref")?  // Completely remove from example
+//!     .finish()
+//!     .await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## JSON Pointer Syntax
+//!
+//! Redaction uses [JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901)
+//! to specify paths:
+//!
+//! | Pointer | Description |
+//! |---------|-------------|
+//! | `/id` | Top-level field "id" |
+//! | `/user/name` | Nested field "name" inside "user" |
+//! | `/items/0` | First element of "items" array |
+//! | `/items/0/id` | "id" of first element in "items" |
+//! | `/foo~1bar` | Field named "foo/bar" (/ escaped as ~1) |
+//! | `/foo~0bar` | Field named "foo~bar" (~ escaped as ~0) |
+//!
+//! ### Nested Object Example
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! #[derive(Deserialize, ToSchema)]
+//! struct Order {
+//!     id: String,
+//!     customer: Customer,
+//!     items: Vec<Item>,
+//! }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct Customer {
+//!     id: String,
+//!     email: String,
+//! }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct Item {
+//!     sku: String,
+//!     quantity: u32,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let result = client.get("/orders/123")?
+//!     .await?
+//!     .as_json_redacted::<Order>()
+//!     .await?
+//!     .redact_replace("/id", "order-001")?
+//!     .redact_replace("/customer/id", "customer-001")?
+//!     .redact_replace("/customer/email", "user@example.com")?
+//!     .redact_replace("/items/0/sku", "SKU-001")?
+//!     .finish()
+//!     .await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## The RedactedResult
+//!
+//! The `finish()` method returns a `RedactedResult`:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Debug, Deserialize, ToSchema)]
+//! # struct User { id: String, name: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! # let result = client.get("/users/1")?.await?.as_json_redacted::<User>().await?
+//! #     .redact_replace("/id", "user-001")?.finish().await;
+//! // result.value: The deserialized struct with REAL values
+//! let user: User = result.value;
+//! println!("Real ID: {}", user.id);  // e.g., "550e8400-e29b-..."
+//!
+//! // result.redacted: JSON with STABLE values (used in OpenAPI)
+//! let json: serde_json::Value = result.redacted;
+//! println!("Redacted: {}", json["id"]);  // "user-001"
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Common Patterns
+//!
+//! ### UUIDs
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Entity { id: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! # let builder = client.get("/test")?.await?.as_json_redacted::<Entity>().await?;
+//! // Use a recognizable placeholder format
+//! builder.redact_replace("/id", "00000000-0000-0000-0000-000000000001")?
+//! # .finish().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Timestamps
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct Entity { created_at: String, updated_at: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! # let builder = client.get("/test")?.await?.as_json_redacted::<Entity>().await?;
+//! // Use ISO 8601 format with a memorable date
+//! builder
+//!     .redact_replace("/created_at", "2024-01-01T00:00:00Z")?
+//!     .redact_replace("/updated_at", "2024-01-01T12:00:00Z")?
+//! # .finish().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Tokens and Secrets
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Deserialize;
+//! # use utoipa::ToSchema;
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct AuthResponse { access_token: String, refresh_token: String }
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! # let builder = client.get("/test")?.await?.as_json_redacted::<AuthResponse>().await?;
+//! // Use descriptive placeholders
+//! builder
+//!     .redact_replace("/access_token", "[ACCESS_TOKEN]")?
+//!     .redact_replace("/refresh_token", "[REFRESH_TOKEN]")?
+//! # .finish().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Enable with `features = ["redaction"]` in Cargo.toml
+//! - Use `as_json_redacted()` instead of `as_json()`
+//! - `redact_replace()` substitutes values, `redact_remove()` deletes them
+//! - JSON Pointer syntax specifies paths to redact
+//! - `finish()` returns both real values (for tests) and redacted values (for docs)
+//!
+//! Next: [Chapter 7: Test Integration][super::chapter_7] - Using TestClient for
+//! end-to-end testing.

--- a/lib/clawspec-core/src/_tutorial/chapter_7.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_7.rs
@@ -1,0 +1,328 @@
+//! # Chapter 7: Test Integration
+//!
+//! This chapter covers using [`TestClient`][crate::test_client::TestClient] for
+//! end-to-end testing with automatic server lifecycle management.
+//!
+//! ## Why TestClient?
+//!
+//! While [`ApiClient`][crate::ApiClient] works against any HTTP server,
+//! [`TestClient`][crate::test_client::TestClient] provides:
+//!
+//! - **Automatic server startup** on a random port
+//! - **Health checking** with exponential backoff
+//! - **Automatic cleanup** when tests complete
+//! - **Direct access** to all `ApiClient` methods
+//!
+//! ## Implementing TestServer
+//!
+//! First, implement the [`TestServer`][crate::test_client::TestServer] trait for your server:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::{TestServer, TestServerConfig, HealthStatus};
+//! use clawspec_core::ApiClient;
+//! use std::net::TcpListener;
+//!
+//! #[derive(Debug)]
+//! struct MyAppServer;
+//!
+//! impl TestServer for MyAppServer {
+//!     type Error = std::io::Error;
+//!
+//!     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//!         // Convert to async listener
+//!         listener.set_nonblocking(true)?;
+//!         let listener = tokio::net::TcpListener::from_std(listener)?;
+//!
+//!         // Start your server (Axum, Actix, Warp, etc.)
+//!         // my_app::run(listener).await?;
+//!
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! ## Custom Health Checks
+//!
+//! Override `is_healthy` for custom health checking:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::{TestServer, HealthStatus};
+//! use clawspec_core::ApiClient;
+//! use std::net::TcpListener;
+//!
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! impl TestServer for MyAppServer {
+//!     type Error = std::io::Error;
+//!
+//!     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//!         listener.set_nonblocking(true)?;
+//!         let _ = tokio::net::TcpListener::from_std(listener)?;
+//!         Ok(())
+//!     }
+//!
+//!     async fn is_healthy(&self, client: &mut ApiClient) -> Result<HealthStatus, Self::Error> {
+//!         // Check your actual health endpoint
+//!         match client.get("/health")
+//!             .expect("valid path")
+//!             .without_collection()  // Don't include in OpenAPI
+//!             .await
+//!         {
+//!             Ok(_) => Ok(HealthStatus::Healthy),
+//!             Err(_) => Ok(HealthStatus::Unhealthy),
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Configuring the Test Server
+//!
+//! Use [`TestServerConfig`][crate::test_client::TestServerConfig] for customization:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::{TestServer, TestServerConfig};
+//! use clawspec_core::ApiClient;
+//! use utoipa::openapi::{InfoBuilder, ServerBuilder};
+//! use std::net::TcpListener;
+//! use std::time::Duration;
+//!
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! impl TestServer for MyAppServer {
+//!     type Error = std::io::Error;
+//!
+//!     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//!         listener.set_nonblocking(true)?;
+//!         let _ = tokio::net::TcpListener::from_std(listener)?;
+//!         Ok(())
+//!     }
+//!
+//!     fn config(&self) -> TestServerConfig {
+//!         // Configure the API client with metadata
+//!         let client_builder = ApiClient::builder()
+//!             .with_base_path("/api/v1").expect("valid path")
+//!             .with_info(
+//!                 InfoBuilder::new()
+//!                     .title("My API")
+//!                     .version("1.0.0")
+//!                     .build()
+//!             )
+//!             .add_server(
+//!                 ServerBuilder::new()
+//!                     .url("https://api.example.com")
+//!                     .description(Some("Production"))
+//!                     .build()
+//!             );
+//!
+//!         TestServerConfig {
+//!             api_client: Some(client_builder),
+//!             min_backoff_delay: Duration::from_millis(10),
+//!             max_backoff_delay: Duration::from_secs(5),
+//!             backoff_jitter: true,
+//!             max_retry_attempts: 20,
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Writing Tests
+//!
+//! Use [`TestClient::start`][crate::test_client::TestClient::start] in your tests:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::TestClient;
+//! # use clawspec_core::test_client::TestServer;
+//! # use std::net::TcpListener;
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! # impl TestServer for MyAppServer {
+//! #     type Error = std::io::Error;
+//! #     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//! #         listener.set_nonblocking(true)?;
+//! #         let _ = tokio::net::TcpListener::from_std(listener)?;
+//! #         Ok(())
+//! #     }
+//! # }
+//! use serde::{Deserialize, Serialize};
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, ToSchema)]
+//! struct CreateUser { name: String }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User { id: u64, name: String }
+//!
+//! #[tokio::test]
+//! async fn test_user_crud() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Start server and get client
+//!     let mut client = TestClient::start(MyAppServer).await?;
+//!
+//!     // Create user
+//!     let user: User = client.post("/users")?
+//!         .json(&CreateUser { name: "Alice".to_string() })?
+//!         .with_tag("users")
+//!         .await?
+//!         .as_json()
+//!         .await?;
+//!
+//!     assert_eq!(user.name, "Alice");
+//!
+//!     // Get user
+//!     let fetched: User = client.get(format!("/users/{}", user.id))?
+//!         .with_tag("users")
+//!         .await?
+//!         .as_json()
+//!         .await?;
+//!
+//!     assert_eq!(fetched.id, user.id);
+//!
+//!     Ok(())
+//! }  // Server automatically stops when client is dropped
+//! ```
+//!
+//! ## Generating OpenAPI
+//!
+//! Use [`write_openapi`][crate::test_client::TestClient::write_openapi] to save the spec:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::TestClient;
+//! # use clawspec_core::test_client::TestServer;
+//! # use std::net::TcpListener;
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! # impl TestServer for MyAppServer {
+//! #     type Error = std::io::Error;
+//! #     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//! #         listener.set_nonblocking(true)?;
+//! #         let _ = tokio::net::TcpListener::from_std(listener)?;
+//! #         Ok(())
+//! #     }
+//! # }
+//!
+//! #[tokio::test]
+//! async fn generate_openapi() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut client = TestClient::start(MyAppServer).await?;
+//!
+//!     // Exercise all your API endpoints...
+//!     client.get("/users")?.with_tag("users").await?;
+//!     client.post("/users")?.with_tag("users").await?;
+//!     client.get("/users/1")?.with_tag("users").await?;
+//!     client.delete("/users/1")?.with_tag("users").await?;
+//!
+//!     // Generate OpenAPI spec (format detected by extension)
+//!     client.write_openapi("docs/openapi.yml").await?;
+//!     // Or JSON: client.write_openapi("docs/openapi.json").await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Test Organization Pattern
+//!
+//! A common pattern is to have a dedicated test for OpenAPI generation:
+//!
+//! ```rust,no_run
+//! // tests/generate_openapi.rs
+//! use clawspec_core::test_client::TestClient;
+//! # use clawspec_core::test_client::TestServer;
+//! # use std::net::TcpListener;
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! # impl TestServer for MyAppServer {
+//! #     type Error = std::io::Error;
+//! #     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//! #         listener.set_nonblocking(true)?;
+//! #         let _ = tokio::net::TcpListener::from_std(listener)?;
+//! #         Ok(())
+//! #     }
+//! # }
+//!
+//! #[tokio::test]
+//! async fn generate_openapi() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut client = TestClient::start(MyAppServer).await?;
+//!
+//!     // Call helper functions that exercise different parts of the API
+//!     test_users_endpoints(&mut client).await?;
+//!     test_posts_endpoints(&mut client).await?;
+//!     test_error_cases(&mut client).await?;
+//!
+//!     // Generate the spec
+//!     client.write_openapi("docs/openapi.yml").await?;
+//!
+//!     Ok(())
+//! }
+//!
+//! async fn test_users_endpoints(client: &mut TestClient<MyAppServer>) -> Result<(), Box<dyn std::error::Error>> {
+//!     client.get("/users")?
+//!         .with_tag("users")
+//!         .with_description("List all users")
+//!         .await?;
+//!     // ... more user endpoints
+//!     Ok(())
+//! }
+//! # async fn test_posts_endpoints(client: &mut TestClient<MyAppServer>) -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
+//! # async fn test_error_cases(client: &mut TestClient<MyAppServer>) -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
+//! ```
+//!
+//! ## Accessing the Underlying Client
+//!
+//! `TestClient` derefs to `ApiClient`, so all methods are available:
+//!
+//! ```rust,no_run
+//! use clawspec_core::test_client::TestClient;
+//! # use clawspec_core::test_client::TestServer;
+//! # use std::net::TcpListener;
+//! # #[derive(Debug)]
+//! # struct MyAppServer;
+//! # impl TestServer for MyAppServer {
+//! #     type Error = std::io::Error;
+//! #     async fn launch(&self, listener: TcpListener) -> Result<(), Self::Error> {
+//! #         listener.set_nonblocking(true)?;
+//! #         let _ = tokio::net::TcpListener::from_std(listener)?;
+//! #         Ok(())
+//! #     }
+//! # }
+//! # use serde::{Serialize, Deserialize};
+//! # use utoipa::ToSchema;
+//! # #[derive(Serialize, Deserialize, ToSchema)]
+//! # struct MySchema { field: String }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = TestClient::start(MyAppServer).await?;
+//!
+//! // All ApiClient methods work directly
+//! client.register_schema::<MySchema>().await;
+//! let spec = client.collected_openapi().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Key Points
+//!
+//! - Implement [`TestServer`][crate::test_client::TestServer] for your web framework
+//! - Override `is_healthy()` for custom health checking
+//! - Override `config()` for API metadata and timing settings
+//! - Use `TestClient::start()` in tests for automatic lifecycle management
+//! - Use `write_openapi()` to generate specs in YAML or JSON format
+//! - Server stops automatically when `TestClient` is dropped
+//!
+//! ## Complete Example
+//!
+//! For a full working example with Axum, see the
+//! [axum-example](https://github.com/ilaborie/clawspec/tree/main/examples/axum-example)
+//! in the Clawspec repository.
+//!
+//! ---
+//!
+//! Congratulations! You've completed the Clawspec tutorial. You now know how to:
+//!
+//! - Create and configure API clients
+//! - Make requests with various parameters
+//! - Handle different response types
+//! - Customize OpenAPI output
+//! - Use redaction for stable examples
+//! - Integrate with test frameworks
+//!
+//! For more details, explore the [API documentation][crate] or check out the
+//! [GitHub repository](https://github.com/ilaborie/clawspec).

--- a/lib/clawspec-core/src/_tutorial/mod.rs
+++ b/lib/clawspec-core/src/_tutorial/mod.rs
@@ -1,0 +1,65 @@
+//! # Tutorial: Getting Started with Clawspec
+//!
+//! Welcome to the Clawspec tutorial! This guide will walk you through using Clawspec
+//! to generate OpenAPI specifications from your test code.
+//!
+//! ## Learning Path
+//!
+//! This tutorial is organized into chapters that build upon each other:
+//!
+//! 1. **[Introduction][chapter_0]** - What is Clawspec and why use it
+//! 2. **[Getting Started][chapter_1]** - Setting up the client and making your first request
+//! 3. **[Request Building][chapter_2]** - POST requests, path and query parameters
+//! 4. **[Response Handling][chapter_3]** - Processing responses and error handling
+//! 5. **[Advanced Parameters][chapter_4]** - Headers, cookies, and parameter styles
+//! 6. **[OpenAPI Customization][chapter_5]** - Tags, descriptions, and metadata
+//! 7. **[Redaction][chapter_6]** - Stable examples with dynamic value redaction
+//! 8. **[Test Integration][chapter_7]** - Using TestClient for end-to-end testing
+//!
+//! ## Quick Example
+//!
+//! Here's a taste of what you'll learn:
+//!
+//! ```rust,no_run
+//! use clawspec_core::ApiClient;
+//! use serde::{Deserialize, Serialize};
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Serialize, ToSchema)]
+//! struct CreateUser { name: String }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct User { id: u64, name: String }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create a client
+//! let mut client = ApiClient::builder()
+//!     .with_host("api.example.com")
+//!     .build()?;
+//!
+//! // Make a request - schema is captured automatically
+//! let user: User = client
+//!     .post("/users")?
+//!     .json(&CreateUser { name: "Alice".to_string() })?
+//!     .await?
+//!     .as_json()
+//!     .await?;
+//!
+//! // Generate OpenAPI specification
+//! let spec = client.collected_openapi().await;
+//! println!("{}", spec.to_pretty_json()?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Ready to start? Head to [Chapter 0: Introduction][chapter_0]!
+
+pub mod chapter_0;
+pub mod chapter_1;
+pub mod chapter_2;
+pub mod chapter_3;
+pub mod chapter_4;
+pub mod chapter_5;
+pub mod chapter_6;
+pub mod chapter_7;

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -8,6 +8,8 @@
 //! - **[`ApiClient`]** - Direct HTTP client for fine-grained control
 //! - **[`TestClient`](test_client::TestClient)** - Test server integration with automatic lifecycle management
 //!
+//! **New to Clawspec?** Start with the **[Tutorial][_tutorial]** for a step-by-step guide.
+//!
 //! ## Quick Start
 //!
 //! ### Using ApiClient directly
@@ -288,13 +290,11 @@
 //! // Single codes
 //! client.post("/users")?
 //!     .with_expected_status_codes(expected_status_codes!(201, 202))
-//!     
 //!     .await?;
 //!
 //! // Ranges
 //! client.get("/health")?
 //!     .with_expected_status_codes(expected_status_codes!(200-299))
-//!     
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -415,11 +415,20 @@
 //! - `/items/0/id` - First element's "id" in an array
 //! - `/foo~1bar` - Field named "foo/bar"
 //!
-//! ### Getting Both Values
-//!
-//! The [`RedactedResult`] returned by `finish()` contains both:
-//! - `value`: The actual deserialized response (with real dynamic values)
-//! - `redacted`: The JSON with redacted values (as stored in OpenAPI)
+#![cfg_attr(feature = "redaction", doc = "### Getting Both Values")]
+#![cfg_attr(feature = "redaction", doc = "")]
+#![cfg_attr(
+    feature = "redaction",
+    doc = "The [`RedactedResult`] returned by `finish()` contains both:"
+)]
+#![cfg_attr(
+    feature = "redaction",
+    doc = "- `value`: The actual deserialized response (with real dynamic values)"
+)]
+#![cfg_attr(
+    feature = "redaction",
+    doc = "- `redacted`: The JSON with redacted values (as stored in OpenAPI)"
+)]
 //!
 #![cfg_attr(feature = "redaction", doc = "```rust")]
 #![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
@@ -551,6 +560,8 @@
 //! All commonly used types are re-exported from the crate root for convenience.
 
 // TODO: Add comprehensive unit tests for all modules - https://github.com/ilaborie/clawspec/issues/30
+
+pub mod _tutorial;
 
 mod client;
 


### PR DESCRIPTION
## Summary

- Add a winnow-inspired tutorial module (`_tutorial`) with 8 progressive chapters
- Fix formatting issues in existing lib.rs documentation
- Fix feature-gated documentation links for `RedactedResult`

## Tutorial Chapters

| Chapter | Title | Topics |
|---------|-------|--------|
| `chapter_0` | Introduction | What is Clawspec, why test-driven docs, prerequisites |
| `chapter_1` | Getting Started | Creating clients, first GET request, generating specs |
| `chapter_2` | Request Building | POST with JSON, path params, query params, HTTP methods |
| `chapter_3` | Response Handling | `as_json`, `as_optional_json`, `as_result_json`, error handling |
| `chapter_4` | Advanced Parameters | Headers, cookies, authentication, parameter styles |
| `chapter_5` | OpenAPI Customization | Tags, descriptions, API info, servers, schema registration |
| `chapter_6` | Redaction | Feature flag, redact_replace, redact_remove, JSON Pointer syntax |
| `chapter_7` | Test Integration | TestServer trait, TestClient, health checks, write_openapi |

## Changes

- Created `lib/clawspec-core/src/_tutorial/` module with 9 files
- Updated `lib.rs` to reference the tutorial with a prominent link
- Fixed code example formatting (extra blank lines)
- Fixed `RedactedResult` link to be feature-gated

## Test plan

- [x] `cargo doc` builds without warnings
- [x] `cargo doc --features redaction` builds without warnings
- [x] All doc tests pass (`cargo test --doc`)
- [x] `mise run check` passes (format, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)