### PR TITLE
refactor(clawspec-core): replace Arc<RwLock<Collectors>> with channels

### DIFF
--- a/lib/clawspec-core/src/client/call/mod.rs
+++ b/lib/clawspec-core/src/client/call/mod.rs
@@ -1,10 +1,7 @@
-use std::sync::Arc;
-
 use http::{Method, Uri};
-use tokio::sync::RwLock;
 
 use super::call_parameters::OperationMetadata;
-use super::openapi::Collectors;
+use super::openapi::channel::CollectorSender;
 use super::response::ExpectedStatusCodes;
 use super::{CallBody, CallCookies, CallHeaders, CallPath, CallQuery};
 
@@ -102,7 +99,8 @@ mod tests;
 pub struct ApiCall {
     pub(super) client: reqwest::Client,
     pub(super) base_uri: Uri,
-    pub(super) collectors: Arc<RwLock<Collectors>>,
+    #[debug(skip)]
+    pub(super) collector_sender: CollectorSender,
 
     pub(super) method: Method,
     pub(super) path: CallPath,

--- a/lib/clawspec-core/src/client/call/tests.rs
+++ b/lib/clawspec-core/src/client/call/tests.rs
@@ -1,16 +1,14 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 
 use http::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 use url::Url;
 use utoipa::ToSchema;
 
 use super::*;
 use crate::client::call_parameters::{CallParameters, OperationMetadata};
-use crate::client::openapi::Collectors;
+use crate::client::openapi::channel::CollectorSender;
 use crate::client::response::ExpectedStatusCodes;
 use crate::client::{CallHeaders, CallPath, CallQuery, ParamValue};
 use crate::{ApiClientError, CallResult};
@@ -24,12 +22,19 @@ struct TestData {
 // Helper function to create a basic ApiCall for testing
 fn create_test_api_call() -> ApiCall {
     let client = reqwest::Client::new();
-    let base_uri = "http://localhost:8080".parse().unwrap();
-    let collectors = Arc::new(RwLock::new(Collectors::default()));
+    let base_uri = "http://localhost:8080".parse().expect("valid uri");
     let method = Method::GET;
     let path = CallPath::from("/test");
 
-    ApiCall::build(client, base_uri, collectors, method, path, None).unwrap()
+    ApiCall::build(
+        client,
+        base_uri,
+        CollectorSender::dummy(),
+        method,
+        path,
+        None,
+    )
+    .expect("should build api call")
 }
 
 // Test OperationMetadata creation and defaults

--- a/lib/clawspec-core/src/client/openapi/channel.rs
+++ b/lib/clawspec-core/src/client/openapi/channel.rs
@@ -1,0 +1,167 @@
+use std::any::TypeId;
+
+use headers::ContentType;
+use http::StatusCode;
+use tokio::sync::{mpsc, oneshot};
+use utoipa::openapi::{RefOr, Schema};
+
+use super::collectors::Collectors;
+use super::operation::CalledOperation;
+use super::schema::{SchemaEntry, Schemas};
+
+/// Channel buffer size for collector messages.
+const CHANNEL_BUFFER_SIZE: usize = 256;
+
+/// Messages sent to the collector task for schema and operation collection.
+pub(in crate::client) enum CollectorMessage {
+    /// Add schemas from path/query/header parameters.
+    AddSchemas(Schemas),
+
+    /// Add a single schema entry (e.g., from request body).
+    AddSchemaEntry(SchemaEntry),
+
+    /// Add an example to an existing schema by TypeId.
+    AddExample {
+        type_id: TypeId,
+        type_name: &'static str,
+        example: serde_json::Value,
+    },
+
+    /// Register a complete operation after HTTP call.
+    RegisterOperation(CalledOperation),
+
+    /// Register a response for an operation.
+    RegisterResponse {
+        operation_id: String,
+        status: StatusCode,
+        content_type: Option<ContentType>,
+        schema: Option<RefOr<Schema>>,
+        description: String,
+    },
+
+    /// Register a response with an example value.
+    RegisterResponseWithExample {
+        operation_id: String,
+        status: StatusCode,
+        content_type: Option<ContentType>,
+        schema: RefOr<Schema>,
+        example: serde_json::Value,
+    },
+
+    /// Request to retrieve final Collectors for OpenAPI generation.
+    GetCollectors(oneshot::Sender<Collectors>),
+}
+
+/// Sender for collector messages, encapsulating the channel implementation.
+#[derive(Debug, Clone)]
+pub(in crate::client) struct CollectorSender {
+    inner: mpsc::Sender<CollectorMessage>,
+}
+
+impl CollectorSender {
+    /// Creates a dummy sender for skip_collection cases.
+    pub(in crate::client) fn dummy() -> Self {
+        let (sender, _) = mpsc::channel::<CollectorMessage>(1);
+        Self { inner: sender }
+    }
+
+    /// Sends a message to the collector task.
+    pub(in crate::client) async fn send(&self, msg: CollectorMessage) {
+        self.inner
+            .send(msg)
+            .await
+            .expect("Collector task should be running");
+    }
+}
+
+/// Handle for sending messages to the collector task.
+#[derive(Debug, Clone)]
+pub(in crate::client) struct CollectorHandle {
+    sender: CollectorSender,
+}
+
+impl CollectorHandle {
+    /// Creates a new collector task and returns a handle.
+    pub(in crate::client) fn spawn() -> Self {
+        let (sender, receiver) = mpsc::channel::<CollectorMessage>(CHANNEL_BUFFER_SIZE);
+
+        tokio::spawn(collector_task(receiver));
+
+        Self {
+            sender: CollectorSender { inner: sender },
+        }
+    }
+
+    /// Returns a clone of the sender for passing to ApiCall/CallResult.
+    pub(in crate::client) fn sender(&self) -> CollectorSender {
+        self.sender.clone()
+    }
+
+    /// Request final collectors for OpenAPI generation.
+    pub(in crate::client) async fn get_collectors(&self) -> Collectors {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send(CollectorMessage::GetCollectors(tx)).await;
+        rx.await.expect("Collector task should respond")
+    }
+}
+
+/// Background task that receives collector messages and updates the Collectors.
+async fn collector_task(mut receiver: mpsc::Receiver<CollectorMessage>) {
+    let mut collectors = Collectors::default();
+
+    while let Some(msg) = receiver.recv().await {
+        match msg {
+            CollectorMessage::AddSchemas(schemas) => {
+                collectors.collect_schemas(schemas);
+            }
+            CollectorMessage::AddSchemaEntry(entry) => {
+                collectors.collect_schema_entry(entry);
+            }
+            CollectorMessage::AddExample {
+                type_id,
+                type_name,
+                example,
+            } => {
+                collectors
+                    .schemas
+                    .add_example_by_id(type_id, type_name, example);
+            }
+            CollectorMessage::RegisterOperation(operation) => {
+                collectors.collect_operation(operation);
+            }
+            CollectorMessage::RegisterResponse {
+                operation_id,
+                status,
+                content_type,
+                schema,
+                description,
+            } => {
+                collectors.register_response(
+                    &operation_id,
+                    status,
+                    content_type.as_ref(),
+                    schema,
+                    description,
+                );
+            }
+            CollectorMessage::RegisterResponseWithExample {
+                operation_id,
+                status,
+                content_type,
+                schema,
+                example,
+            } => {
+                collectors.register_response_with_example(
+                    &operation_id,
+                    status,
+                    content_type.as_ref(),
+                    schema,
+                    example,
+                );
+            }
+            CollectorMessage::GetCollectors(responder) => {
+                let _ = responder.send(collectors.clone());
+            }
+        }
+    }
+}

--- a/lib/clawspec-core/src/client/openapi/mod.rs
+++ b/lib/clawspec-core/src/client/openapi/mod.rs
@@ -1,3 +1,4 @@
+pub(in crate::client) mod channel;
 pub(in crate::client) mod schema;
 
 mod result;

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -940,16 +940,16 @@ mod integration_tests {
         assert!(auth.contains(403)); // Forbidden
     }
 
-    #[test]
-    fn test_expected_status_codes_with_api_call() {
+    #[tokio::test]
+    async fn test_expected_status_codes_with_api_call() {
         // This tests that the macro works correctly with actual API calls
-        let client = ApiClient::builder().build().unwrap();
+        let client = ApiClient::builder().build().expect("should build client");
         let codes = expected_status_codes!(200 - 299, 404);
 
         // Should compile and be usable
         let _call = client
             .get("/test")
-            .unwrap()
+            .expect("should create call")
             .with_expected_status_codes(codes);
     }
 


### PR DESCRIPTION
## Summary

- Replace `Arc<RwLock<Collectors>>` with channel-based message passing to reduce lock contention
- Add `CollectorMessage` enum for typed messages sent to collector task
- Add `CollectorSender` newtype wrapping `mpsc::Sender` to encapsulate channel implementation
- Add `CollectorHandle` for spawning and managing the collector task
- Compute schema references locally with `compute_schema_ref<T>()` to avoid shared state access
- Use fire-and-forget `send().await` in hot paths for guaranteed delivery

## Test plan

- [x] All 329 clawspec-core tests pass
- [x] All 27 axum-example integration tests pass
- [x] All 177 doc tests pass
- [x] Clippy passes with no warnings
- [x] Spectral OpenAPI validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)