### PR TITLE
fix: Replace removed `doc_auto_cfg` with `doc_cfg` for docs.rs

### DIFF
--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # Clawspec Core
 //!


### PR DESCRIPTION
## Summary

- Fix docs.rs build failure by replacing the removed `doc_auto_cfg` feature with `doc_cfg`
- The `doc_auto_cfg` feature was removed in Rust 1.92.0 and merged into `doc_cfg` (see [rust-lang/rust#138907](https://github.com/rust-lang/rust/pull/138907))

## Test plan

- [x] `cargo check -p clawspec-core` passes
- [x] `mise run check` passes (format, lint, 356 tests)
- [x] `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p clawspec-core --all-features` generates docs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)