### PR TITLE
feat(clawspec-core): add request body redaction support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ insta = "1.44.3"
 assert2 = "0.3.15"
 tracing-subscriber = "0.3.22"
 criterion = "0.8.1"
+wiremock = "0.6"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/examples/axum-example/doc/openapi.yml
+++ b/examples/axum-example/doc/openapi.yml
@@ -115,6 +115,12 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/FlatObservation'
+            example:
+              name: Form Bird
+              lng: 2.5
+              lat: 3.5
+              color: orange
+              notes: Created via form encoding
           text/xml:
             schema:
               type: string

--- a/examples/axum-example/tests/common/client.rs
+++ b/examples/axum-example/tests/common/client.rs
@@ -147,6 +147,49 @@ impl TestApp {
         Ok(result.value)
     }
 
+    /// Creates an observation with request body redaction.
+    ///
+    /// This method demonstrates the request body redaction feature where
+    /// sensitive fields are redacted in the `OpenAPI` example but the original
+    /// values are sent in the HTTP request.
+    pub async fn create_observation_with_redacted_request(
+        &mut self,
+        new_observation: &PartialObservation,
+    ) -> anyhow::Result<Observation> {
+        let result = self
+            .post("/observations")?
+            .json_redacted(new_observation)?
+            .redact("/notes", "[INTERNAL_NOTES_REDACTED]")?
+            .await
+            .context("create observation with redacted request")?
+            .as_json()
+            .await?;
+        Ok(result)
+    }
+
+    /// Creates an observation with both request and response body redaction.
+    ///
+    /// This method demonstrates the full redaction workflow where both the
+    /// request body and response body are redacted in the `OpenAPI` examples.
+    pub async fn create_observation_with_full_redaction(
+        &mut self,
+        new_observation: &PartialObservation,
+    ) -> anyhow::Result<Observation> {
+        let result = self
+            .post("/observations")?
+            .json_redacted(new_observation)?
+            .redact("/notes", "[INTERNAL_NOTES_REDACTED]")?
+            .await
+            .context("create observation with full redaction")?
+            .as_json_redacted::<Observation>()
+            .await?
+            .redact("/id", "019aaaaa-0000-7000-8000-000000000000")?
+            .redact("/created_at", "2024-01-01T00:00:00Z")?
+            .finish()
+            .await;
+        Ok(result.value)
+    }
+
     pub async fn update_observation(
         &mut self,
         id: ObservationId,

--- a/examples/axum-example/tests/test_request_body_redaction.rs
+++ b/examples/axum-example/tests/test_request_body_redaction.rs
@@ -1,0 +1,334 @@
+#![allow(missing_docs)]
+
+//! Integration tests for the request body redaction feature.
+//!
+//! These tests verify that redacted request body examples appear correctly in the
+//! generated `OpenAPI` specification. The request body redaction feature allows
+//! hiding sensitive values (like passwords, API keys, internal notes) from the
+//! `OpenAPI` documentation while sending the real values in the HTTP request.
+
+use anyhow::Context;
+use rstest::rstest;
+use tracing::info;
+use utoipa::openapi::RefOr;
+
+use axum_example::observations::domain::{LngLat, PartialObservation};
+
+mod common;
+pub use self::common::*;
+
+/// Tests that redacted request body examples appear in the `OpenAPI` request content.
+///
+/// This test verifies that when using `json_redacted()` with redaction
+/// replacements, the redacted example values appear in the generated `OpenAPI`
+/// specification's request body content.
+///
+/// The redacted value should be:
+/// - notes: `[INTERNAL_NOTES_REDACTED]` (sensitive internal notes hidden)
+#[rstest]
+#[tokio::test]
+async fn test_redacted_request_body_appears_in_openapi(
+    #[future] app: TestApp,
+) -> anyhow::Result<()> {
+    let mut app = app.await;
+
+    info!("Testing that redacted request body examples appear in OpenAPI request content");
+
+    let new_observation = PartialObservation {
+        name: "Request Body Redaction Test Bird".to_string(),
+        position: LngLat { lng: 1.0, lat: 2.0 },
+        color: Some("red".to_string()),
+        notes: Some("SENSITIVE: Internal tracking code ABC-123".to_string()),
+    };
+
+    // Create observation using request body redaction
+    let created = app
+        .create_observation_with_redacted_request(&new_observation)
+        .await
+        .context("should create observation with redacted request body")?;
+
+    info!(
+        "Created observation with id={} and notes={:?}",
+        created.id, created.data.notes
+    );
+
+    // Verify the actual observation has the original notes (not redacted)
+    let actual_notes = created.data.notes.as_deref();
+    assert_eq!(
+        actual_notes,
+        Some("SENSITIVE: Internal tracking code ABC-123"),
+        "actual notes should be the original value, sent in the HTTP request"
+    );
+
+    // Generate OpenAPI spec
+    let openapi_spec = app.collected_openapi().await;
+
+    // Find the POST /observations operation
+    let paths = &openapi_spec.paths;
+    let observations_path = paths
+        .paths
+        .get("/api/observations")
+        .expect("should have /api/observations path");
+
+    let post_operation = observations_path
+        .post
+        .as_ref()
+        .expect("should have POST operation");
+
+    // Find the request body - it's already a RequestBody, not RefOr
+    let request_body = post_operation
+        .request_body
+        .as_ref()
+        .expect("should have request body");
+
+    // Get the application/json content
+    let json_content = request_body
+        .content
+        .get("application/json")
+        .expect("should have application/json content");
+
+    // Verify that the example contains the redacted value
+    let example = json_content
+        .example
+        .as_ref()
+        .expect("request body content should have an example with redacted values");
+
+    info!("Found example in request body: {}", example);
+
+    // Verify the example contains the REDACTED notes (not the actual sensitive value)
+    let example_notes = example
+        .get("notes")
+        .expect("example should have 'notes' field")
+        .as_str()
+        .expect("notes should be a string");
+
+    assert_eq!(
+        example_notes, "[INTERNAL_NOTES_REDACTED]",
+        "example notes should be the redacted placeholder, not the actual sensitive value"
+    );
+    assert_ne!(
+        example_notes, "SENSITIVE: Internal tracking code ABC-123",
+        "example notes should not contain the actual sensitive value"
+    );
+
+    // Verify non-redacted fields are preserved in the example
+    let example_name = example
+        .get("name")
+        .expect("example should have 'name' field")
+        .as_str()
+        .expect("name should be a string");
+
+    assert_eq!(
+        example_name, "Request Body Redaction Test Bird",
+        "example should contain the original name (not redacted)"
+    );
+
+    info!("Request body redaction test passed successfully");
+
+    Ok(())
+}
+
+/// Tests that both request and response body can be redacted together.
+///
+/// This test verifies the full redaction workflow where:
+/// - Request body has sensitive notes redacted
+/// - Response body has dynamic id and `created_at` redacted
+#[rstest]
+#[tokio::test]
+async fn test_full_request_and_response_redaction(#[future] app: TestApp) -> anyhow::Result<()> {
+    let mut app = app.await;
+
+    info!("Testing combined request and response body redaction");
+
+    let new_observation = PartialObservation {
+        name: "Full Redaction Test Bird".to_string(),
+        position: LngLat { lng: 3.0, lat: 4.0 },
+        color: Some("blue".to_string()),
+        notes: Some("SECRET: This should not appear in docs".to_string()),
+    };
+
+    // Create observation with full redaction (both request and response)
+    let created = Box::pin(app.create_observation_with_full_redaction(&new_observation))
+        .await
+        .context("should create observation with full redaction")?;
+
+    info!(
+        "Created observation with id={} and notes={:?}",
+        created.id, created.data.notes
+    );
+
+    // Verify the actual observation has the original notes
+    assert_eq!(
+        created.data.notes.as_deref(),
+        Some("SECRET: This should not appear in docs"),
+        "actual notes should be the original value"
+    );
+
+    // Verify the actual id is dynamic (not the redacted value)
+    assert_ne!(
+        created.id.to_string(),
+        "019aaaaa-0000-7000-8000-000000000000",
+        "actual id should be a dynamic UUID"
+    );
+
+    // Generate OpenAPI spec
+    let openapi_spec = app.collected_openapi().await;
+
+    // Find the POST /observations operation
+    let paths = &openapi_spec.paths;
+    let observations_path = paths
+        .paths
+        .get("/api/observations")
+        .expect("should have /api/observations path");
+
+    let post_operation = observations_path
+        .post
+        .as_ref()
+        .expect("should have POST operation");
+
+    // Check request body example - it's already a RequestBody, not RefOr
+    let request_body = post_operation
+        .request_body
+        .as_ref()
+        .expect("should have request body");
+
+    let request_content = request_body
+        .content
+        .get("application/json")
+        .expect("should have application/json content");
+
+    let request_example = request_content
+        .example
+        .as_ref()
+        .expect("request body should have example");
+
+    // Verify request body has redacted notes
+    let request_notes = request_example
+        .get("notes")
+        .and_then(serde_json::Value::as_str)
+        .expect("request example should have notes");
+
+    assert_eq!(
+        request_notes, "[INTERNAL_NOTES_REDACTED]",
+        "request body example notes should be redacted"
+    );
+
+    // Check response example (201 response)
+    let responses = &post_operation.responses;
+    let response_201 = responses
+        .responses
+        .get("201")
+        .expect("should have 201 response");
+
+    let response = match response_201 {
+        RefOr::T(response) => response,
+        RefOr::Ref(_) => panic!("expected inline response, got reference"),
+    };
+
+    let response_content = response
+        .content
+        .get("application/json")
+        .expect("should have application/json content");
+
+    let response_example = response_content
+        .example
+        .as_ref()
+        .expect("response should have example");
+
+    // Verify response has redacted id and created_at
+    let response_id = response_example
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("response example should have id");
+
+    assert_eq!(
+        response_id, "019aaaaa-0000-7000-8000-000000000000",
+        "response body example id should be the redacted stable UUID"
+    );
+
+    let response_created_at = response_example
+        .get("created_at")
+        .and_then(serde_json::Value::as_str)
+        .expect("response example should have created_at");
+
+    assert_eq!(
+        response_created_at, "2024-01-01T00:00:00Z",
+        "response body example created_at should be the redacted stable timestamp"
+    );
+
+    info!("Full request and response redaction test passed successfully");
+
+    Ok(())
+}
+
+/// Tests that non-redacted request bodies still have examples from `json()`.
+///
+/// This test establishes the baseline behavior: regular `json()` calls
+/// produce examples (from the serialized value), while `json_redacted()`
+/// with explicit redactions produces the redacted example.
+#[rstest]
+#[tokio::test]
+async fn test_request_body_example_from_regular_json(#[future] app: TestApp) -> anyhow::Result<()> {
+    let mut app = app.await;
+
+    info!("Testing that regular json() calls produce request body examples");
+
+    let new_observation = PartialObservation {
+        name: "Regular JSON Test Bird".to_string(),
+        position: LngLat { lng: 5.0, lat: 6.0 },
+        color: Some("green".to_string()),
+        notes: Some("Regular notes here".to_string()),
+    };
+
+    // Create observation with regular json() (no redaction)
+    let _created = app
+        .create_observation(&new_observation)
+        .await
+        .context("should create observation")?;
+
+    // Generate OpenAPI spec
+    let openapi_spec = app.collected_openapi().await;
+
+    // Find the POST /observations operation
+    let paths = &openapi_spec.paths;
+    let observations_path = paths
+        .paths
+        .get("/api/observations")
+        .expect("should have /api/observations path");
+
+    let post_operation = observations_path
+        .post
+        .as_ref()
+        .expect("should have POST operation");
+
+    // Find the request body - it's already a RequestBody, not RefOr
+    let request_body = post_operation
+        .request_body
+        .as_ref()
+        .expect("should have request body");
+
+    // Get the application/json content
+    let json_content = request_body
+        .content
+        .get("application/json")
+        .expect("should have application/json content");
+
+    // Regular json() calls should produce an example with the actual values
+    let example = json_content
+        .example
+        .as_ref()
+        .expect("regular json() should produce an example");
+
+    // The example should have the original notes (not redacted)
+    let example_notes = example.get("notes").and_then(serde_json::Value::as_str);
+
+    assert_eq!(
+        example_notes,
+        Some("Regular notes here"),
+        "regular json() example should have the original notes"
+    );
+
+    info!("Regular JSON request body example test passed successfully");
+
+    Ok(())
+}

--- a/lib/clawspec-core/Cargo.toml
+++ b/lib/clawspec-core/Cargo.toml
@@ -60,6 +60,7 @@ tokio = { workspace = true, features = ["full"]}
 insta = { workspace = true }
 serde-saphyr = { workspace = true}
 criterion = { workspace = true }
+wiremock = { workspace = true }
 # Force minimum versions for minimal-versions CI (annotate-snippets has incorrect anstyle dep)
 annotate-snippets = { workspace = true }
 anstyle = { workspace = true }

--- a/lib/clawspec-core/src/_tutorial/chapter_6.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_6.rs
@@ -434,10 +434,178 @@
 //! # }
 //! ```
 //!
+//! ## Request Body Redaction
+//!
+//! The same redaction patterns work for request bodies too. When sending POST/PUT/PATCH
+//! requests with sensitive data, you can redact values in the OpenAPI documentation
+//! while sending the real data in the HTTP request.
+//!
+//! **Key principle:**
+//! - **HTTP Request**: Uses the original value with real data for testing
+//! - **OpenAPI Example**: Uses the redacted value with stable placeholders
+//!
+//! ### Basic Usage
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! use clawspec_core::ApiClient;
+//! use serde::Serialize;
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct LoginRequest {
+//!     username: String,
+//!     password: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let request = LoginRequest {
+//!     username: "alice".to_string(),
+//!     password: "my-secret-password".to_string(),
+//! };
+//!
+//! // Use json_redacted() instead of json()
+//! client
+//!     .post("/auth/login")?
+//!     .json_redacted(&request)?
+//!     .redact("/password", "[REDACTED]")?
+//!     .await?;  // Executes the HTTP request
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Redacting Multiple Fields
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Serialize;
+//! # use utoipa::ToSchema;
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct CreateApiKey {
+//!     name: String,
+//!     secret: String,
+//!     internal_ref: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let request = CreateApiKey {
+//!     name: "my-key".to_string(),
+//!     secret: "sk-live-abc123def456".to_string(),
+//!     internal_ref: "internal-id-789".to_string(),
+//! };
+//!
+//! client
+//!     .post("/api-keys")?
+//!     .json_redacted(&request)?
+//!     .redact("/secret", "[REDACTED_SECRET]")?
+//!     .redact_remove("/internal_ref")?  // Remove entirely from docs
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Using JSONPath Wildcards
+//!
+//! For arrays, use JSONPath syntax to redact all matching fields:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::Serialize;
+//! # use utoipa::ToSchema;
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct BulkCreateUsers {
+//!     users: Vec<UserData>,
+//! }
+//!
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct UserData {
+//!     name: String,
+//!     password: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let request = BulkCreateUsers {
+//!     users: vec![
+//!         UserData { name: "alice".into(), password: "secret1".into() },
+//!         UserData { name: "bob".into(), password: "secret2".into() },
+//!     ],
+//! };
+//!
+//! // Redact ALL passwords in the array
+//! client
+//!     .post("/users/bulk")?
+//!     .json_redacted(&request)?
+//!     .redact("$.users[*].password", "[REDACTED]")?
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Response and Request Redaction Together
+//!
+//! You can combine request body and response redaction in the same test:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! # use clawspec_core::ApiClient;
+//! # use serde::{Serialize, Deserialize};
+//! # use utoipa::ToSchema;
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct CreateUserRequest {
+//!     username: String,
+//!     password: String,
+//! }
+//!
+//! #[derive(Deserialize, ToSchema)]
+//! struct CreateUserResponse {
+//!     id: String,
+//!     username: String,
+//!     created_at: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut client = ApiClient::builder().build()?;
+//! let request = CreateUserRequest {
+//!     username: "alice".to_string(),
+//!     password: "secret123".to_string(),
+//! };
+//!
+//! // Redact request body (password hidden in docs)
+//! let mut response = client
+//!     .post("/users")?
+//!     .json_redacted(&request)?
+//!     .redact("/password", "[REDACTED]")?
+//!     .await?;
+//!
+//! // Redact response body (stable IDs and timestamps)
+//! let result = response
+//!     .as_json_redacted::<CreateUserResponse>()
+//!     .await?
+//!     .redact("/id", "user-00000000")?
+//!     .redact("/created_at", "2024-01-01T00:00:00Z")?
+//!     .finish()
+//!     .await;
+//!
+//! // Test assertions use real values
+//! assert!(!result.value.id.is_empty());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## Key Points
 //!
 //! - Enable with `features = ["redaction"]` in Cargo.toml
-//! - Use `as_json_redacted()` instead of `as_json()`
+//! - **Response redaction**: Use `as_json_redacted()` instead of `as_json()`
+//! - **Request body redaction**: Use `json_redacted()` instead of `json()`
 //! - Paths are auto-detected:
 //!   - `/...` - JSON Pointer (RFC 6901) for exact paths
 //!   - `$...` - JSONPath (RFC 9535) for wildcards

--- a/lib/clawspec-core/src/client/call/builder.rs
+++ b/lib/clawspec-core/src/client/call/builder.rs
@@ -6,6 +6,8 @@ use utoipa::ToSchema;
 use super::ApiCall;
 use crate::client::parameters::{ParamValue, ParameterValue};
 use crate::client::response::ExpectedStatusCodes;
+#[cfg(feature = "redaction")]
+use crate::client::response::RequestBodyRedactionBuilder;
 use crate::client::security::SecurityRequirement;
 use crate::client::{ApiClientError, CallBody, CallCookies, CallHeaders, CallQuery};
 
@@ -781,6 +783,152 @@ impl ApiCall {
         let body = CallBody::json(t)?;
         self.body = Some(body);
         Ok(self)
+    }
+
+    /// Sets the request body to JSON with redaction support for OpenAPI examples.
+    ///
+    /// This method returns a [`RequestBodyRedactionBuilder`] that allows you to
+    /// redact sensitive values (like passwords, API keys, tokens) in the OpenAPI
+    /// documentation while sending the original values in the HTTP request.
+    ///
+    /// **Key principle:**
+    /// - **HTTP Request**: Uses the original value with real data for testing
+    /// - **OpenAPI Example**: Uses the redacted value with stable placeholders
+    ///
+    /// This is useful when you want to:
+    /// - Hide sensitive credentials in documentation
+    /// - Create stable, deterministic OpenAPI examples
+    /// - Test with real data while documenting with sanitized examples
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The type to serialize. Must implement `Serialize`, `ToSchema`, and `Clone`.
+    ///
+    /// # Examples
+    ///
+    /// ## Basic Usage
+    ///
+    /// ```rust
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[derive(Clone, Serialize, ToSchema)]
+    /// struct LoginRequest {
+    ///     username: String,
+    ///     password: String,
+    /// }
+    ///
+    /// let mut client = ApiClient::builder().build()?;
+    /// let request = LoginRequest {
+    ///     username: "alice".to_string(),
+    ///     password: "secret123".to_string(),
+    /// };
+    ///
+    /// // The HTTP request will contain the real password,
+    /// // but the OpenAPI example will show "[REDACTED]"
+    /// client
+    ///     .post("/auth/login")?
+    ///     .json_redacted(&request)?
+    ///     .redact("/password", "[REDACTED]")?
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## Multiple Redactions
+    ///
+    /// ```rust
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[derive(Clone, Serialize, ToSchema)]
+    /// struct CreateApiKey {
+    ///     name: String,
+    ///     secret: String,
+    ///     internal_id: String,
+    /// }
+    ///
+    /// let mut client = ApiClient::builder().build()?;
+    /// let request = CreateApiKey {
+    ///     name: "my-key".to_string(),
+    ///     secret: "sk-live-abc123def456".to_string(),
+    ///     internal_id: "internal-ref-789".to_string(),
+    /// };
+    ///
+    /// client
+    ///     .post("/api-keys")?
+    ///     .json_redacted(&request)?
+    ///     .redact("/secret", "[REDACTED_SECRET]")?
+    ///     .redact_remove("/internal_id")?  // Remove entirely from docs
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## JSONPath Wildcards
+    ///
+    /// ```rust
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[derive(Clone, Serialize, ToSchema)]
+    /// struct BulkCreateUsers {
+    ///     users: Vec<UserData>,
+    /// }
+    ///
+    /// #[derive(Clone, Serialize, ToSchema)]
+    /// struct UserData {
+    ///     name: String,
+    ///     password: String,
+    /// }
+    ///
+    /// let mut client = ApiClient::builder().build()?;
+    /// let request = BulkCreateUsers {
+    ///     users: vec![
+    ///         UserData { name: "alice".to_string(), password: "secret1".to_string() },
+    ///         UserData { name: "bob".to_string(), password: "secret2".to_string() },
+    ///     ],
+    /// };
+    ///
+    /// // Redact ALL passwords in the array
+    /// client
+    ///     .post("/users/bulk")?
+    ///     .json_redacted(&request)?
+    ///     .redact("$.users[*].password", "[REDACTED]")?
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if JSON serialization fails.
+    ///
+    /// # Feature Flag
+    ///
+    /// This method requires the `redaction` feature to be enabled:
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// clawspec-core = { version = "...", features = ["redaction"] }
+    /// ```
+    #[cfg(feature = "redaction")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "redaction")))]
+    pub fn json_redacted<T>(self, t: &T) -> Result<RequestBodyRedactionBuilder<T>, ApiClientError>
+    where
+        T: Serialize + ToSchema + Clone + 'static,
+    {
+        let body = CallBody::json_without_example(t)?;
+        let json_value = serde_json::to_value(t)?;
+        Ok(RequestBodyRedactionBuilder::new(
+            t.clone(),
+            json_value,
+            body,
+            self,
+        ))
     }
 
     /// Sets the request body to form-encoded data.

--- a/lib/clawspec-core/src/client/mod.rs
+++ b/lib/clawspec-core/src/client/mod.rs
@@ -22,7 +22,8 @@ mod response;
 pub use self::response::ExpectedStatusCodes;
 #[cfg(feature = "redaction")]
 pub use self::response::{
-    RedactOptions, RedactedResult, RedactionBuilder, Redactor, ValueRedactionBuilder, redact_value,
+    RedactOptions, RedactedResult, RedactionBuilder, Redactor, RequestBodyRedactionBuilder,
+    ValueRedactionBuilder, redact_value,
 };
 
 mod auth;

--- a/lib/clawspec-core/src/client/openapi/operation.rs
+++ b/lib/clawspec-core/src/client/openapi/operation.rs
@@ -73,7 +73,12 @@ impl CalledOperation {
         let builder = if let Some(body) = request_body {
             let schema_ref = schemas.add_entry(body.entry.clone());
             let content_type = normalize_content_type(&body.content_type);
-            let example = if body.content_type == ContentType::json() {
+
+            // Use the example from the schema entry if available (for redaction support),
+            // otherwise deserialize from the body data
+            let example = if !body.entry.examples.is_empty() {
+                body.entry.examples.first().cloned()
+            } else if body.content_type == ContentType::json() {
                 serde_json::from_slice(&body.data).ok()
             } else {
                 None

--- a/lib/clawspec-core/src/client/parameters/body.rs
+++ b/lib/clawspec-core/src/client/parameters/body.rs
@@ -215,6 +215,39 @@ impl CallBody {
             data: body_data,
         }
     }
+
+    /// Creates a JSON body without setting an example.
+    ///
+    /// This method is used internally by the redaction feature to create a body
+    /// where the example will be set later after redaction is applied.
+    ///
+    /// The original value is serialized for the HTTP request, but no example
+    /// is added to the schema entry. The example will be set separately with
+    /// the redacted value for OpenAPI documentation.
+    #[cfg(feature = "redaction")]
+    pub(crate) fn json_without_example<T>(t: &T) -> Result<Self, ApiClientError>
+    where
+        T: Serialize + ToSchema + 'static,
+    {
+        let content_type = ContentType::json();
+        let entry = SchemaEntry::of::<T>(); // No example yet
+        let data = serde_json::to_vec(t)?;
+
+        Ok(Self {
+            content_type,
+            entry,
+            data,
+        })
+    }
+
+    /// Sets the example on the schema entry.
+    ///
+    /// This method is used internally by the redaction feature to set the
+    /// redacted example value for OpenAPI documentation.
+    #[cfg(feature = "redaction")]
+    pub(crate) fn set_example(&mut self, example: serde_json::Value) {
+        self.entry.add_example(example);
+    }
 }
 
 #[cfg(test)]

--- a/lib/clawspec-core/src/client/response/mod.rs
+++ b/lib/clawspec-core/src/client/response/mod.rs
@@ -11,8 +11,9 @@ pub use self::status::ExpectedStatusCodes;
 pub(in crate::client) mod output;
 
 #[cfg(feature = "redaction")]
-mod redaction;
+pub(in crate::client) mod redaction;
 #[cfg(feature = "redaction")]
 pub use self::redaction::{
-    RedactOptions, RedactedResult, RedactionBuilder, Redactor, ValueRedactionBuilder, redact_value,
+    RedactOptions, RedactedResult, RedactionBuilder, Redactor, RequestBodyRedactionBuilder,
+    ValueRedactionBuilder, redact_value,
 };

--- a/lib/clawspec-core/src/client/response/redaction/mod.rs
+++ b/lib/clawspec-core/src/client/response/redaction/mod.rs
@@ -100,9 +100,11 @@ use super::output::Output;
 mod apply;
 mod path_selector;
 mod redactor;
+mod request_body;
 mod value_builder;
 
 pub use self::redactor::Redactor;
+pub use self::request_body::RequestBodyRedactionBuilder;
 pub use self::value_builder::ValueRedactionBuilder;
 use crate::client::CallResult;
 use crate::client::error::ApiClientError;

--- a/lib/clawspec-core/src/client/response/redaction/mod.rs
+++ b/lib/clawspec-core/src/client/response/redaction/mod.rs
@@ -987,4 +987,113 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+    struct LoginResponse {
+        session_token: String,
+        user_id: String,
+    }
+
+    fn get_response_example(
+        openapi: &utoipa::openapi::OpenApi,
+        path: &str,
+        method: &str,
+        status_code: &str,
+    ) -> Option<serde_json::Value> {
+        let path_item = openapi.paths.paths.get(path)?;
+        let operation = match method.to_uppercase().as_str() {
+            "POST" => path_item.post.as_ref(),
+            "PUT" => path_item.put.as_ref(),
+            "PATCH" => path_item.patch.as_ref(),
+            "DELETE" => path_item.delete.as_ref(),
+            "GET" => path_item.get.as_ref(),
+            _ => None,
+        }?;
+        let response = operation.responses.responses.get(status_code)?;
+        let utoipa::openapi::RefOr::T(response) = response else {
+            return None;
+        };
+        let content = response.content.get("application/json")?;
+        content.example.clone()
+    }
+
+    #[tokio::test]
+    async fn should_return_original_value_and_use_redacted_in_openapi_for_response() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use crate::client::ApiClient;
+
+        // 1. Start mock server
+        let mock_server = MockServer::start().await;
+
+        // 2. Set up mock to return a response with sensitive data
+        Mock::given(method("POST"))
+            .and(path("/api/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "session_token": "secret-token-abc123",
+                "user_id": "user-42"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // 3. Create ApiClient pointing to mock server
+        let uri: http::Uri = mock_server.uri().parse().expect("valid URI");
+        let mut client = ApiClient::builder()
+            .with_host(uri.host().expect("should have host"))
+            .with_port(uri.port_u16().expect("should have port"))
+            .build()
+            .expect("should build client");
+
+        // 4. Make request and apply response redaction
+        let result = client
+            .post("/api/login")
+            .expect("should create call")
+            .await
+            .expect("request should succeed")
+            .as_json_redacted::<LoginResponse>()
+            .await
+            .expect("should parse response")
+            .redact("/session_token", "[REDACTED]")
+            .expect("should redact")
+            .finish()
+            .await;
+
+        // 5. Verify the returned value contains the ORIGINAL (unredacted) data
+        assert_eq!(
+            result.value.session_token, "secret-token-abc123",
+            "Original value should have real session token"
+        );
+        assert_eq!(
+            result.value.user_id, "user-42",
+            "Original value should have real user_id"
+        );
+
+        // 6. Verify the redacted field in the result
+        assert_eq!(
+            result
+                .redacted
+                .get("session_token")
+                .and_then(|v| v.as_str()),
+            Some("[REDACTED]"),
+            "Redacted result should have redacted session_token"
+        );
+
+        // 7. Verify OpenAPI example contains the redacted value
+        let openapi = client.collected_openapi().await;
+        let example = get_response_example(&openapi, "/api/login", "POST", "200")
+            .expect("should have response example");
+
+        assert_eq!(
+            example.get("session_token").and_then(|v| v.as_str()),
+            Some("[REDACTED]"),
+            "OpenAPI example should have redacted session_token"
+        );
+        assert_eq!(
+            example.get("user_id").and_then(|v| v.as_str()),
+            Some("user-42"),
+            "OpenAPI example should have original user_id"
+        );
+    }
 }

--- a/lib/clawspec-core/src/client/response/redaction/request_body.rs
+++ b/lib/clawspec-core/src/client/response/redaction/request_body.rs
@@ -1,0 +1,700 @@
+//! Request body redaction support for OpenAPI documentation.
+//!
+//! This module provides functionality to redact sensitive values in JSON request bodies
+//! before they are stored as examples in the OpenAPI specification. The key principle is:
+//!
+//! - **Original value for HTTP**: The actual serialized data is sent in the HTTP request
+//! - **Redacted value for OpenAPI**: The redacted value is used for documentation examples
+//!
+//! This allows you to test with real data while keeping your OpenAPI examples clean,
+//! stable, and free of sensitive information.
+//!
+//! # Path Syntax
+//!
+//! The path syntax is auto-detected based on the prefix:
+//! - Paths starting with `$` use JSONPath (RFC 9535) - supports wildcards
+//! - Paths starting with `/` use JSON Pointer (RFC 6901) - exact paths only
+//!
+//! # Example
+//!
+//! ```ignore
+//! use clawspec_core::ApiClient;
+//! use serde::Serialize;
+//! use utoipa::ToSchema;
+//!
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct CreateUser {
+//!     username: String,
+//!     password: String,
+//!     api_key: String,
+//! }
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut client = ApiClient::builder().build()?;
+//!
+//! let user = CreateUser {
+//!     username: "alice".to_string(),
+//!     password: "secret123".to_string(),
+//!     api_key: "sk-live-abc123".to_string(),
+//! };
+//!
+//! // The HTTP request will contain the real password and API key,
+//! // but the OpenAPI example will show the redacted values.
+//! client
+//!     .post("/users")?
+//!     .json_redacted(&user)?
+//!     .redact("/password", "[REDACTED]")?
+//!     .redact("/api_key", "[REDACTED]")?
+//!     .await?;  // IntoFuture - no .finish() needed
+//! # Ok(())
+//! # }
+//! ```
+
+use std::future::{Future, IntoFuture};
+use std::pin::Pin;
+
+use utoipa::ToSchema;
+
+use super::RedactOptions;
+use super::apply::{apply_redaction, apply_remove};
+use super::redactor::Redactor;
+use crate::client::call::ApiCall;
+use crate::client::error::ApiClientError;
+use crate::client::{CallBody, CallResult};
+
+/// Builder for redacting sensitive values in JSON request bodies.
+///
+/// This builder allows you to apply redactions to a JSON request body before
+/// it's used in the OpenAPI documentation. The original (unredacted) value
+/// is sent in the actual HTTP request.
+///
+/// # Key Principle
+///
+/// - **HTTP Request**: Uses the original value with real data for testing
+/// - **OpenAPI Example**: Uses the redacted value with stable placeholders
+///
+/// This separation allows you to:
+/// - Test with realistic data (passwords, tokens, API keys)
+/// - Generate stable OpenAPI documentation (no dynamic values)
+/// - Hide sensitive information from documentation
+///
+/// # Path Syntax
+///
+/// Paths are auto-detected based on their prefix:
+/// - `/...` → JSON Pointer (RFC 6901) for exact paths
+/// - `$...` → JSONPath (RFC 9535) for wildcards
+///
+/// # Example
+///
+/// ```ignore
+/// use clawspec_core::ApiClient;
+/// use serde::Serialize;
+/// use utoipa::ToSchema;
+///
+/// #[derive(Clone, Serialize, ToSchema)]
+/// struct LoginRequest {
+///     email: String,
+///     password: String,
+/// }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut client = ApiClient::builder().build()?;
+///
+/// let request = LoginRequest {
+///     email: "user@example.com".to_string(),
+///     password: "my-secret-password".to_string(),
+/// };
+///
+/// client
+///     .post("/auth/login")?
+///     .json_redacted(&request)?
+///     .redact("/password", "[REDACTED]")?
+///     .await?;  // IntoFuture - no .finish() needed
+/// # Ok(())
+/// # }
+/// ```
+#[derive(derive_more::Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "redaction")))]
+pub struct RequestBodyRedactionBuilder<T> {
+    /// The original value (kept for reference, used in HTTP request via body.data)
+    #[debug(skip)]
+    value: T,
+    /// The JSON representation for redaction operations
+    redacted: serde_json::Value,
+    /// The body being built (contains serialized data for HTTP)
+    body: CallBody,
+    /// The ApiCall to return when finished
+    #[debug(skip)]
+    api_call: ApiCall,
+}
+
+impl<T> RequestBodyRedactionBuilder<T> {
+    /// Creates a new request body redaction builder.
+    pub(crate) fn new(
+        value: T,
+        redacted: serde_json::Value,
+        body: CallBody,
+        api_call: ApiCall,
+    ) -> Self {
+        Self {
+            value,
+            redacted,
+            body,
+            api_call,
+        }
+    }
+
+    /// Redacts values at the specified path using a redactor.
+    ///
+    /// The path can be either JSON Pointer (RFC 6901) or JSONPath (RFC 9535).
+    /// The syntax is auto-detected based on the prefix:
+    /// - `$...` → JSONPath (supports wildcards)
+    /// - `/...` → JSON Pointer (exact path)
+    ///
+    /// The redactor can be:
+    /// - A static value: `"replacement"` or `serde_json::json!(...)`
+    /// - A closure: `|path, val| transform(path, val)`
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path expression (e.g., `/password`, `$.users[*].token`)
+    /// * `redactor` - The redactor to apply (static value or closure)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is invalid
+    /// - The path matches no values
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # #[derive(Clone, Serialize, ToSchema)]
+    /// # struct Request { token: String }
+    /// # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// // Static value
+    /// client.post("/api")?
+    ///     .json_redacted(&Request { token: "secret".into() })?
+    ///     .redact("/token", "[REDACTED]")?
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn redact<R: Redactor>(self, path: &str, redactor: R) -> Result<Self, ApiClientError> {
+        self.redact_with_options(path, redactor, RedactOptions::default())
+    }
+
+    /// Redacts values at the specified path with configurable options.
+    ///
+    /// This is like [`redact`](Self::redact) but allows customizing
+    /// behavior through [`RedactOptions`].
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path expression (e.g., `/password`, `$.users[*].token`)
+    /// * `redactor` - The redactor to apply
+    /// * `options` - Configuration options
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use clawspec_core::RedactOptions;
+    ///
+    /// // Allow empty matches for optional fields
+    /// let options = RedactOptions { allow_empty_match: true };
+    ///
+    /// builder
+    ///     .redact_with_options("$.optional_field", "value", options)?
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// ```
+    pub fn redact_with_options<R: Redactor>(
+        mut self,
+        path: &str,
+        redactor: R,
+        options: RedactOptions,
+    ) -> Result<Self, ApiClientError> {
+        apply_redaction(&mut self.redacted, path, redactor, options)?;
+        Ok(self)
+    }
+
+    /// Removes values at the specified path from the OpenAPI example.
+    ///
+    /// This completely removes the field from the OpenAPI documentation example,
+    /// unlike setting it to `null`. The original value is still sent in the HTTP request.
+    ///
+    /// The path can be either JSON Pointer (RFC 6901) or JSONPath (RFC 9535).
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path expression to remove
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is invalid
+    /// - The path matches no values
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # #[derive(Clone, Serialize, ToSchema)]
+    /// # struct Request { password: String, internal_id: String }
+    /// # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// client.post("/api")?
+    ///     .json_redacted(&Request {
+    ///         password: "secret".into(),
+    ///         internal_id: "internal-123".into(),
+    ///     })?
+    ///     .redact("/password", "[REDACTED]")?
+    ///     .redact_remove("/internal_id")?  // Remove entirely from docs
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn redact_remove(self, path: &str) -> Result<Self, ApiClientError> {
+        self.redact_remove_with(path, RedactOptions::default())
+    }
+
+    /// Removes values at the specified path with configurable options.
+    ///
+    /// This is like [`redact_remove`](Self::redact_remove) but allows customizing
+    /// behavior through [`RedactOptions`].
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path expression to remove
+    /// * `options` - Configuration options
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use clawspec_core::RedactOptions;
+    ///
+    /// // Allow empty matches for optional fields
+    /// let options = RedactOptions { allow_empty_match: true };
+    ///
+    /// builder
+    ///     .redact_remove_with("$.optional_field", options)?
+    ///     .await?;  // IntoFuture - no .finish() needed
+    /// ```
+    pub fn redact_remove_with(
+        mut self,
+        path: &str,
+        options: RedactOptions,
+    ) -> Result<Self, ApiClientError> {
+        apply_remove(&mut self.redacted, path, options)?;
+        Ok(self)
+    }
+
+    /// Finalizes the redaction and returns the configured ApiCall.
+    ///
+    /// This consumes the builder and returns the `ApiCall` with the request body
+    /// configured. The body will contain:
+    /// - **HTTP data**: The original (unredacted) serialized value
+    /// - **OpenAPI example**: The redacted value for documentation
+    ///
+    /// After calling `finish()`, you can `.await` the `ApiCall` to execute
+    /// the HTTP request.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// # use clawspec_core::ApiClient;
+    /// # use serde::Serialize;
+    /// # use utoipa::ToSchema;
+    /// # #[derive(Clone, Serialize, ToSchema)]
+    /// # struct Request { password: String }
+    /// # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// let response = client
+    ///     .post("/api")?
+    ///     .json_redacted(&Request { password: "secret".into() })?
+    ///     .redact("/password", "[REDACTED]")?
+    ///     .finish()?  // Returns ApiCall
+    ///     .await?;    // Executes the HTTP request
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn finish(mut self) -> Result<ApiCall, ApiClientError>
+    where
+        T: ToSchema + 'static,
+    {
+        // Set the redacted example on the body
+        self.body.set_example(self.redacted);
+
+        // Set the body on the ApiCall
+        self.api_call.body = Some(self.body);
+
+        Ok(self.api_call)
+    }
+
+    /// Returns a reference to the original (unredacted) value.
+    ///
+    /// This can be useful if you need to inspect the original value
+    /// while building the redactions.
+    pub fn original_value(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns a reference to the current redacted JSON value.
+    ///
+    /// This can be useful if you need to inspect the redacted state
+    /// while building the redactions.
+    pub fn redacted_value(&self) -> &serde_json::Value {
+        &self.redacted
+    }
+}
+
+/// Implements `IntoFuture` to allow direct `.await` on the builder.
+///
+/// This enables a more ergonomic API where you can write:
+///
+/// ```ignore
+/// client
+///     .post("/users")?
+///     .json_redacted(&user)?
+///     .redact("/password", "[REDACTED]")?
+///     .await?;  // No need for .finish()?
+/// ```
+///
+/// Instead of:
+///
+/// ```ignore
+/// client
+///     .post("/users")?
+///     .json_redacted(&user)?
+///     .redact("/password", "[REDACTED]")?
+///     .finish()?
+///     .await?;
+/// ```
+impl<T> IntoFuture for RequestBodyRedactionBuilder<T>
+where
+    T: ToSchema + 'static,
+{
+    type Output = Result<CallResult, ApiClientError>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        // Call finish() synchronously to avoid capturing self in the async block
+        match self.finish() {
+            Ok(api_call) => api_call.into_future(),
+            Err(e) => Box::pin(async move { Err(e) }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use utoipa::ToSchema;
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+    struct TestRequest {
+        username: String,
+        password: String,
+        api_key: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+    struct NestedRequest {
+        user: UserInfo,
+        items: Vec<Item>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+    struct UserInfo {
+        id: String,
+        token: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+    struct Item {
+        id: String,
+        secret: String,
+    }
+
+    fn create_test_builder() -> RequestBodyRedactionBuilder<TestRequest> {
+        let value = TestRequest {
+            username: "alice".to_string(),
+            password: "secret123".to_string(),
+            api_key: "sk-live-abc123".to_string(),
+        };
+
+        let redacted = json!({
+            "username": "alice",
+            "password": "secret123",
+            "api_key": "sk-live-abc123"
+        });
+
+        let body = CallBody::json_without_example(&value).expect("should create body");
+
+        // Create a minimal ApiCall for testing
+        let client = reqwest::Client::new();
+        let base_uri = "http://localhost:8080".parse().expect("valid URI");
+        let collector_sender = crate::client::openapi::channel::CollectorSender::dummy();
+        let path = crate::client::CallPath::from("/test");
+        let query = crate::client::CallQuery::new();
+        let expected_status_codes = crate::client::response::ExpectedStatusCodes::default();
+        let metadata = crate::client::call_parameters::OperationMetadata::default();
+
+        let api_call = ApiCall {
+            client,
+            base_uri,
+            collector_sender,
+            method: http::Method::POST,
+            path,
+            query,
+            headers: None,
+            body: None,
+            authentication: None,
+            cookies: None,
+            expected_status_codes,
+            metadata,
+            response_description: None,
+            skip_collection: false,
+            security: None,
+        };
+
+        RequestBodyRedactionBuilder::new(value.clone(), redacted, body, api_call)
+    }
+
+    #[test]
+    fn should_redact_single_field() {
+        let builder = create_test_builder();
+        let result = builder.redact("/password", "[REDACTED]");
+
+        assert!(result.is_ok());
+        let builder = result.expect("redaction should succeed");
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        // Other fields unchanged
+        assert_eq!(
+            builder.redacted.get("username").and_then(|v| v.as_str()),
+            Some("alice")
+        );
+        assert_eq!(
+            builder.redacted.get("api_key").and_then(|v| v.as_str()),
+            Some("sk-live-abc123")
+        );
+    }
+
+    #[test]
+    fn should_redact_multiple_fields() {
+        let builder = create_test_builder();
+        let result = builder
+            .redact("/password", "[REDACTED]")
+            .and_then(|b| b.redact("/api_key", "[REDACTED]"));
+
+        assert!(result.is_ok());
+        let builder = result.expect("redaction should succeed");
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        assert_eq!(
+            builder.redacted.get("api_key").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        // Username unchanged
+        assert_eq!(
+            builder.redacted.get("username").and_then(|v| v.as_str()),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn should_redact_with_jsonpath_wildcards() {
+        let value = NestedRequest {
+            user: UserInfo {
+                id: "user-123".to_string(),
+                token: "token-abc".to_string(),
+            },
+            items: vec![
+                Item {
+                    id: "item-1".to_string(),
+                    secret: "secret-1".to_string(),
+                },
+                Item {
+                    id: "item-2".to_string(),
+                    secret: "secret-2".to_string(),
+                },
+            ],
+        };
+
+        let redacted = serde_json::to_value(&value).expect("should serialize");
+        let body = CallBody::json_without_example(&value).expect("should create body");
+
+        let client = reqwest::Client::new();
+        let base_uri = "http://localhost:8080".parse().expect("valid URI");
+        let collector_sender = crate::client::openapi::channel::CollectorSender::dummy();
+        let path = crate::client::CallPath::from("/test");
+        let query = crate::client::CallQuery::new();
+        let expected_status_codes = crate::client::response::ExpectedStatusCodes::default();
+        let metadata = crate::client::call_parameters::OperationMetadata::default();
+
+        let api_call = ApiCall {
+            client,
+            base_uri,
+            collector_sender,
+            method: http::Method::POST,
+            path,
+            query,
+            headers: None,
+            body: None,
+            authentication: None,
+            cookies: None,
+            expected_status_codes,
+            metadata,
+            response_description: None,
+            skip_collection: false,
+            security: None,
+        };
+
+        let builder: RequestBodyRedactionBuilder<NestedRequest> =
+            RequestBodyRedactionBuilder::new(value, redacted, body, api_call);
+
+        let result = builder.redact("$.items[*].secret", "[REDACTED]");
+
+        assert!(result.is_ok());
+        let builder = result.expect("redaction should succeed");
+        let items = builder
+            .redacted
+            .get("items")
+            .and_then(|v| v.as_array())
+            .expect("should have items");
+
+        for item in items {
+            assert_eq!(
+                item.get("secret").and_then(|v| v.as_str()),
+                Some("[REDACTED]")
+            );
+        }
+    }
+
+    #[test]
+    fn should_redact_with_closure() {
+        let builder = create_test_builder();
+        let result = builder.redact("/password", |_path: &str, _val: &serde_json::Value| {
+            json!("redacted-by-closure")
+        });
+
+        assert!(result.is_ok());
+        let builder = result.expect("redaction should succeed");
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("redacted-by-closure")
+        );
+    }
+
+    #[test]
+    fn should_remove_fields() {
+        let builder = create_test_builder();
+        let result = builder.redact_remove("/password");
+
+        assert!(result.is_ok());
+        let builder = result.expect("removal should succeed");
+        assert!(builder.redacted.get("password").is_none());
+        // Other fields still present
+        assert!(builder.redacted.get("username").is_some());
+        assert!(builder.redacted.get("api_key").is_some());
+    }
+
+    #[test]
+    fn should_preserve_original_value() {
+        let builder = create_test_builder();
+        let original_password = builder.value.password.clone();
+
+        let result = builder.redact("/password", "[REDACTED]");
+        assert!(result.is_ok());
+        let builder = result.expect("redaction should succeed");
+
+        // Original value is preserved
+        assert_eq!(builder.value.password, original_password);
+        // Redacted value is different
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+    }
+
+    #[test]
+    fn should_fail_on_invalid_path() {
+        let builder = create_test_builder();
+        let result = builder.redact("$.nonexistent", "[REDACTED]");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_allow_empty_match_with_option() {
+        let builder = create_test_builder();
+        let options = RedactOptions {
+            allow_empty_match: true,
+        };
+        let result = builder.redact_with_options("$.nonexistent", "[REDACTED]", options);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_access_original_and_redacted_values() {
+        let builder = create_test_builder();
+
+        // Check original value access
+        assert_eq!(builder.original_value().username, "alice");
+        assert_eq!(builder.original_value().password, "secret123");
+
+        // Check redacted value access before redaction
+        assert_eq!(
+            builder
+                .redacted_value()
+                .get("password")
+                .and_then(|v| v.as_str()),
+            Some("secret123")
+        );
+
+        // Redact and check again
+        let builder = builder
+            .redact("/password", "[REDACTED]")
+            .expect("should redact");
+        assert_eq!(
+            builder
+                .redacted_value()
+                .get("password")
+                .and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        // Original unchanged
+        assert_eq!(builder.original_value().password, "secret123");
+    }
+
+    #[test]
+    fn should_finish_and_return_api_call() {
+        let builder = create_test_builder();
+        let result = builder
+            .redact("/password", "[REDACTED]")
+            .and_then(|b| b.finish());
+
+        assert!(result.is_ok());
+        let api_call = result.expect("should finish");
+        assert!(api_call.body.is_some());
+    }
+
+    #[test]
+    fn test_debug_impl() {
+        let builder = create_test_builder();
+        let debug_str = format!("{builder:?}");
+
+        assert!(debug_str.contains("RequestBodyRedactionBuilder"));
+    }
+}

--- a/lib/clawspec-core/src/client/response/redaction/request_body.rs
+++ b/lib/clawspec-core/src/client/response/redaction/request_body.rs
@@ -421,22 +421,8 @@ mod tests {
         secret: String,
     }
 
-    fn create_test_builder() -> RequestBodyRedactionBuilder<TestRequest> {
-        let value = TestRequest {
-            username: "alice".to_string(),
-            password: "secret123".to_string(),
-            api_key: "sk-live-abc123".to_string(),
-        };
-
-        let redacted = json!({
-            "username": "alice",
-            "password": "secret123",
-            "api_key": "sk-live-abc123"
-        });
-
-        let body = CallBody::json_without_example(&value).expect("should create body");
-
-        // Create a minimal ApiCall for testing
+    /// Creates a minimal ApiCall for testing purposes.
+    fn create_test_api_call() -> ApiCall {
         let client = reqwest::Client::new();
         let base_uri = "http://localhost:8080".parse().expect("valid URI");
         let collector_sender = crate::client::openapi::channel::CollectorSender::dummy();
@@ -445,7 +431,7 @@ mod tests {
         let expected_status_codes = crate::client::response::ExpectedStatusCodes::default();
         let metadata = crate::client::call_parameters::OperationMetadata::default();
 
-        let api_call = ApiCall {
+        ApiCall {
             client,
             base_uri,
             collector_sender,
@@ -461,59 +447,29 @@ mod tests {
             response_description: None,
             skip_collection: false,
             security: None,
+        }
+    }
+
+    fn create_test_builder() -> RequestBodyRedactionBuilder<TestRequest> {
+        let value = TestRequest {
+            username: "alice".to_string(),
+            password: "secret123".to_string(),
+            api_key: "sk-live-abc123".to_string(),
         };
 
-        RequestBodyRedactionBuilder::new(value.clone(), redacted, body, api_call)
+        let redacted = json!({
+            "username": "alice",
+            "password": "secret123",
+            "api_key": "sk-live-abc123"
+        });
+
+        let body = CallBody::json_without_example(&value).expect("should create body");
+        let api_call = create_test_api_call();
+
+        RequestBodyRedactionBuilder::new(value, redacted, body, api_call)
     }
 
-    #[test]
-    fn should_redact_single_field() {
-        let builder = create_test_builder();
-        let result = builder.redact("/password", "[REDACTED]");
-
-        assert!(result.is_ok());
-        let builder = result.expect("redaction should succeed");
-        assert_eq!(
-            builder.redacted.get("password").and_then(|v| v.as_str()),
-            Some("[REDACTED]")
-        );
-        // Other fields unchanged
-        assert_eq!(
-            builder.redacted.get("username").and_then(|v| v.as_str()),
-            Some("alice")
-        );
-        assert_eq!(
-            builder.redacted.get("api_key").and_then(|v| v.as_str()),
-            Some("sk-live-abc123")
-        );
-    }
-
-    #[test]
-    fn should_redact_multiple_fields() {
-        let builder = create_test_builder();
-        let result = builder
-            .redact("/password", "[REDACTED]")
-            .and_then(|b| b.redact("/api_key", "[REDACTED]"));
-
-        assert!(result.is_ok());
-        let builder = result.expect("redaction should succeed");
-        assert_eq!(
-            builder.redacted.get("password").and_then(|v| v.as_str()),
-            Some("[REDACTED]")
-        );
-        assert_eq!(
-            builder.redacted.get("api_key").and_then(|v| v.as_str()),
-            Some("[REDACTED]")
-        );
-        // Username unchanged
-        assert_eq!(
-            builder.redacted.get("username").and_then(|v| v.as_str()),
-            Some("alice")
-        );
-    }
-
-    #[test]
-    fn should_redact_with_jsonpath_wildcards() {
+    fn create_nested_builder() -> RequestBodyRedactionBuilder<NestedRequest> {
         let value = NestedRequest {
             user: UserInfo {
                 id: "user-123".to_string(),
@@ -533,40 +489,58 @@ mod tests {
 
         let redacted = serde_json::to_value(&value).expect("should serialize");
         let body = CallBody::json_without_example(&value).expect("should create body");
+        let api_call = create_test_api_call();
 
-        let client = reqwest::Client::new();
-        let base_uri = "http://localhost:8080".parse().expect("valid URI");
-        let collector_sender = crate::client::openapi::channel::CollectorSender::dummy();
-        let path = crate::client::CallPath::from("/test");
-        let query = crate::client::CallQuery::new();
-        let expected_status_codes = crate::client::response::ExpectedStatusCodes::default();
-        let metadata = crate::client::call_parameters::OperationMetadata::default();
+        RequestBodyRedactionBuilder::new(value, redacted, body, api_call)
+    }
 
-        let api_call = ApiCall {
-            client,
-            base_uri,
-            collector_sender,
-            method: http::Method::POST,
-            path,
-            query,
-            headers: None,
-            body: None,
-            authentication: None,
-            cookies: None,
-            expected_status_codes,
-            metadata,
-            response_description: None,
-            skip_collection: false,
-            security: None,
-        };
+    #[test]
+    fn should_redact_single_field() {
+        let builder = create_test_builder()
+            .redact("/password", "[REDACTED]")
+            .expect("redaction should succeed");
 
-        let builder: RequestBodyRedactionBuilder<NestedRequest> =
-            RequestBodyRedactionBuilder::new(value, redacted, body, api_call);
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        assert_eq!(
+            builder.redacted.get("username").and_then(|v| v.as_str()),
+            Some("alice")
+        );
+        assert_eq!(
+            builder.redacted.get("api_key").and_then(|v| v.as_str()),
+            Some("sk-live-abc123")
+        );
+    }
 
-        let result = builder.redact("$.items[*].secret", "[REDACTED]");
+    #[test]
+    fn should_redact_multiple_fields() {
+        let builder = create_test_builder()
+            .redact("/password", "[REDACTED]")
+            .and_then(|b| b.redact("/api_key", "[REDACTED]"))
+            .expect("redaction should succeed");
 
-        assert!(result.is_ok());
-        let builder = result.expect("redaction should succeed");
+        assert_eq!(
+            builder.redacted.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        assert_eq!(
+            builder.redacted.get("api_key").and_then(|v| v.as_str()),
+            Some("[REDACTED]")
+        );
+        assert_eq!(
+            builder.redacted.get("username").and_then(|v| v.as_str()),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn should_redact_with_jsonpath_wildcards() {
+        let builder = create_nested_builder()
+            .redact("$.items[*].secret", "[REDACTED]")
+            .expect("redaction should succeed");
+
         let items = builder
             .redacted
             .get("items")
@@ -583,13 +557,12 @@ mod tests {
 
     #[test]
     fn should_redact_with_closure() {
-        let builder = create_test_builder();
-        let result = builder.redact("/password", |_path: &str, _val: &serde_json::Value| {
-            json!("redacted-by-closure")
-        });
+        let builder = create_test_builder()
+            .redact("/password", |_path: &str, _val: &serde_json::Value| {
+                json!("redacted-by-closure")
+            })
+            .expect("redaction should succeed");
 
-        assert!(result.is_ok());
-        let builder = result.expect("redaction should succeed");
         assert_eq!(
             builder.redacted.get("password").and_then(|v| v.as_str()),
             Some("redacted-by-closure")
@@ -598,29 +571,22 @@ mod tests {
 
     #[test]
     fn should_remove_fields() {
-        let builder = create_test_builder();
-        let result = builder.redact_remove("/password");
+        let builder = create_test_builder()
+            .redact_remove("/password")
+            .expect("removal should succeed");
 
-        assert!(result.is_ok());
-        let builder = result.expect("removal should succeed");
         assert!(builder.redacted.get("password").is_none());
-        // Other fields still present
         assert!(builder.redacted.get("username").is_some());
         assert!(builder.redacted.get("api_key").is_some());
     }
 
     #[test]
     fn should_preserve_original_value() {
-        let builder = create_test_builder();
-        let original_password = builder.value.password.clone();
+        let builder = create_test_builder()
+            .redact("/password", "[REDACTED]")
+            .expect("redaction should succeed");
 
-        let result = builder.redact("/password", "[REDACTED]");
-        assert!(result.is_ok());
-        let builder = result.expect("redaction should succeed");
-
-        // Original value is preserved
-        assert_eq!(builder.value.password, original_password);
-        // Redacted value is different
+        assert_eq!(builder.original_value().password, "secret123");
         assert_eq!(
             builder.redacted.get("password").and_then(|v| v.as_str()),
             Some("[REDACTED]")
@@ -629,32 +595,26 @@ mod tests {
 
     #[test]
     fn should_fail_on_invalid_path() {
-        let builder = create_test_builder();
-        let result = builder.redact("$.nonexistent", "[REDACTED]");
+        let result = create_test_builder().redact("$.nonexistent", "[REDACTED]");
 
         assert!(result.is_err());
     }
 
     #[test]
     fn should_allow_empty_match_with_option() {
-        let builder = create_test_builder();
         let options = RedactOptions {
             allow_empty_match: true,
         };
-        let result = builder.redact_with_options("$.nonexistent", "[REDACTED]", options);
+        let result =
+            create_test_builder().redact_with_options("$.nonexistent", "[REDACTED]", options);
 
         assert!(result.is_ok());
     }
 
     #[test]
-    fn should_access_original_and_redacted_values() {
+    fn should_access_redacted_value() {
         let builder = create_test_builder();
 
-        // Check original value access
-        assert_eq!(builder.original_value().username, "alice");
-        assert_eq!(builder.original_value().password, "secret123");
-
-        // Check redacted value access before redaction
         assert_eq!(
             builder
                 .redacted_value()
@@ -663,10 +623,10 @@ mod tests {
             Some("secret123")
         );
 
-        // Redact and check again
         let builder = builder
             .redact("/password", "[REDACTED]")
             .expect("should redact");
+
         assert_eq!(
             builder
                 .redacted_value()
@@ -674,27 +634,110 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("[REDACTED]")
         );
-        // Original unchanged
-        assert_eq!(builder.original_value().password, "secret123");
     }
 
     #[test]
     fn should_finish_and_return_api_call() {
-        let builder = create_test_builder();
-        let result = builder
+        let api_call = create_test_builder()
             .redact("/password", "[REDACTED]")
-            .and_then(|b| b.finish());
+            .and_then(|b| b.finish())
+            .expect("should finish");
 
-        assert!(result.is_ok());
-        let api_call = result.expect("should finish");
         assert!(api_call.body.is_some());
     }
 
-    #[test]
-    fn test_debug_impl() {
-        let builder = create_test_builder();
-        let debug_str = format!("{builder:?}");
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+    struct LoginRequest {
+        username: String,
+        password: String,
+    }
 
-        assert!(debug_str.contains("RequestBodyRedactionBuilder"));
+    fn get_request_body_example(
+        openapi: &utoipa::openapi::OpenApi,
+        path: &str,
+        method: &str,
+    ) -> Option<serde_json::Value> {
+        let path_item = openapi.paths.paths.get(path)?;
+        let operation = match method.to_uppercase().as_str() {
+            "POST" => path_item.post.as_ref(),
+            "PUT" => path_item.put.as_ref(),
+            "PATCH" => path_item.patch.as_ref(),
+            "DELETE" => path_item.delete.as_ref(),
+            "GET" => path_item.get.as_ref(),
+            _ => None,
+        }?;
+        let request_body = operation.request_body.as_ref()?;
+        let content = request_body.content.get("application/json")?;
+        content.example.clone()
+    }
+
+    #[tokio::test]
+    async fn should_send_original_value_to_server_and_use_redacted_in_openapi() {
+        use wiremock::matchers::{body_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use crate::client::ApiClient;
+
+        // 1. Start mock server
+        let mock_server = MockServer::start().await;
+
+        // 2. Set up mock to capture and verify request body
+        // The mock expects the ORIGINAL (unredacted) value
+        Mock::given(method("POST"))
+            .and(path("/api/login"))
+            .and(body_json(json!({
+                "username": "alice",
+                "password": "secret123"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"status": "ok"})))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // 3. Create ApiClient pointing to mock server
+        let uri: http::Uri = mock_server.uri().parse().expect("valid URI");
+        let mut client = ApiClient::builder()
+            .with_host(uri.host().expect("should have host"))
+            .with_port(uri.port_u16().expect("should have port"))
+            .build()
+            .expect("should build client");
+
+        // 4. Make request with redaction
+        let request = LoginRequest {
+            username: "alice".to_string(),
+            password: "secret123".to_string(),
+        };
+
+        client
+            .post("/api/login")
+            .expect("should create call")
+            .json_redacted(&request)
+            .expect("should set body")
+            .redact("/password", "[REDACTED]")
+            .expect("should redact")
+            .await
+            .expect("request should succeed")
+            .as_empty()
+            .await
+            .expect("should complete");
+
+        // 5. Verify mock received the original value (implicit via matcher)
+        // wiremock will fail if body doesn't match
+
+        // 6. Verify OpenAPI example contains redacted value
+        let openapi = client.collected_openapi().await;
+        let example = get_request_body_example(&openapi, "/api/login", "POST")
+            .expect("should have request body example");
+
+        assert_eq!(
+            example.get("password").and_then(|v| v.as_str()),
+            Some("[REDACTED]"),
+            "OpenAPI example should have redacted password"
+        );
+        assert_eq!(
+            example.get("username").and_then(|v| v.as_str()),
+            Some("alice"),
+            "OpenAPI example should have original username"
+        );
     }
 }

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -236,12 +236,47 @@
 //! # }
 //! ```
 //!
+//! ### Request Body Redaction
+//!
+//! The same pattern works for request bodies using `json_redacted()`:
+//!
+#![cfg_attr(feature = "redaction", doc = "```rust")]
+#![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
+//! use clawspec_core::ApiClient;
+//! # use serde::Serialize;
+//! # use utoipa::ToSchema;
+//!
+//! #[derive(Clone, Serialize, ToSchema)]
+//! struct LoginRequest {
+//!     username: String,
+//!     password: String,
+//! }
+//!
+//! # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
+//! let request = LoginRequest {
+//!     username: "alice".to_string(),
+//!     password: "my-secret-password".to_string(),
+//! };
+//!
+//! // The HTTP request contains the real password,
+//! // but the OpenAPI example shows "[REDACTED]"
+//! client
+//!     .post("/auth/login")?
+//!     .json_redacted(&request)?
+//!     .redact("/password", "[REDACTED]")?
+//!     .finish()?
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ### Redaction Operations
 //!
-//! The redaction builder supports two operations using [JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901):
+//! The redaction builder supports two operations using [JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901)
+//! or [JSONPath (RFC 9535)](https://www.rfc-editor.org/rfc/rfc9535):
 //!
-//! - **`redact(pointer, redactor)`**: Replace a value at the given path with a stable value or transformation
-//! - **`redact_remove(pointer)`**: Remove a value entirely from the OpenAPI example
+//! - **`redact(path, redactor)`**: Replace a value at the given path with a stable value or transformation
+//! - **`redact_remove(path)`**: Remove a value entirely from the OpenAPI example
 //!
 #![cfg_attr(feature = "redaction", doc = "```rust")]
 #![cfg_attr(not(feature = "redaction"), doc = "```rust,ignore")]
@@ -526,7 +561,8 @@ pub use http::StatusCode;
 
 #[cfg(feature = "redaction")]
 pub use self::client::{
-    RedactOptions, RedactedResult, RedactionBuilder, Redactor, ValueRedactionBuilder, redact_value,
+    RedactOptions, RedactedResult, RedactionBuilder, Redactor, RequestBodyRedactionBuilder,
+    ValueRedactionBuilder, redact_value,
 };
 
 #[cfg(feature = "oauth2")]


### PR DESCRIPTION
## Summary

- Add request body redaction feature that sends original values in HTTP requests while storing redacted values in OpenAPI examples
- Add mock server tests (using wiremock) to verify both request body and response redaction behavior

## Key Changes

- Added `wiremock` as a dev dependency for integration testing
- Added integration test for request body redaction verification
- Added integration test for response redaction verification

## Test plan

- [x] All existing tests pass (`mise run check`)
- [x] New mock server tests verify redaction behavior
- [x] Spectral linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)