### PR TITLE
feat(clawspec-core): auto-capture nested types via utoipa's ToSchema::schemas()

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -12,4 +12,4 @@ cargo = { binstall = true }
 "cargo:cargo-nextest" = "0.9"
 "cargo:git-cliff" = "latest"
 "cargo:release-plz" = "latest"
-"npm:@stoplight/spectral-cli" = "latest"
+"npm:@stoplight/spectral-cli" = "6.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tracing = "0.1.43"
 # annotate-snippets uses anstyle Display impl (added in 1.0.5)
 annotate-snippets = "0.12.5"
 anstyle = "1.0.5"
+# lazy_static 1.0.0 lacks the local_inner_macros export sharded-slab relies on
+lazy_static = "1.4.0"
 derive_more = { version = "2.1.0", default-features = false, features = ["error", "display", "from", "deref", "deref_mut", "debug"] }
 indexmap = "2.12.1"
 slug = "0.1.6"

--- a/examples/axum-example/doc/openapi.yml
+++ b/examples/axum-example/doc/openapi.yml
@@ -291,8 +291,6 @@ paths:
             example:
               color: red
               name: Partially Updated Parrot
-              notes: null
-              position: null
       responses:
         '200':
           description: Status code 200

--- a/examples/axum-example/src/observations/domain.rs
+++ b/examples/axum-example/src/observations/domain.rs
@@ -53,9 +53,13 @@ pub struct LngLat {
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, ToSchema)]
 pub struct PatchObservation {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<LngLat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
 }
 

--- a/examples/axum-example/tests/snapshots/test_json_schema_capture__json_schema_capture_without_explicit_registration.snap
+++ b/examples/axum-example/tests/snapshots/test_json_schema_capture__json_schema_capture_without_explicit_registration.snap
@@ -70,6 +70,9 @@ components:
               example: "2024-01-01T00:00:00Z"
             id:
               $ref: "#/components/schemas/ObservationId"
+    ObservationId:
+      type: string
+      format: uuid
     PartialObservation:
       type: object
       required:

--- a/examples/axum-example/tests/test_json_schema_capture.rs
+++ b/examples/axum-example/tests/test_json_schema_capture.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use anyhow::Context;
-use clawspec_core::register_schemas;
 use rstest::rstest;
 use tracing::info;
 
@@ -17,8 +16,9 @@ async fn test_json_schema_capture_without_explicit_registration(
 ) -> anyhow::Result<()> {
     let mut app = app.await;
 
-    register_schemas!(app, LngLat).await;
-
+    // No explicit `register_schemas!(app, LngLat)` call: LngLat is only reachable as a
+    // nested field of PartialObservation, and must be captured automatically via
+    // utoipa's recursive ToSchema::schemas() walk.
     info!("Testing JSON schema capture with only create observation endpoint");
     let new_observation = PartialObservation {
         name: "Test Bird for Schema Capture".to_string(),
@@ -55,6 +55,10 @@ async fn test_json_schema_capture_without_explicit_registration(
     assert!(
         schemas.contains_key("PartialObservation"),
         "PartialObservation schema should be captured"
+    );
+    assert!(
+        schemas.contains_key("LngLat"),
+        "LngLat schema should be captured automatically as a nested type, with no explicit registration"
     );
 
     Ok(())

--- a/examples/axum-example/tests/test_json_schema_capture.rs
+++ b/examples/axum-example/tests/test_json_schema_capture.rs
@@ -16,9 +16,10 @@ async fn test_json_schema_capture_without_explicit_registration(
 ) -> anyhow::Result<()> {
     let mut app = app.await;
 
-    // No explicit `register_schemas!(app, LngLat)` call: LngLat is only reachable as a
-    // nested field of PartialObservation, and must be captured automatically via
-    // utoipa's recursive ToSchema::schemas() walk.
+    // No explicit `register_schemas!(app, LngLat)` call: LngLat is never registered directly
+    // and is never itself a top-level body/response type. It is only reached as a nested field
+    // (of PartialObservation, and transitively of the flattened Observation response), so it
+    // must be captured automatically via utoipa's recursive ToSchema::schemas() walk.
     info!("Testing JSON schema capture with only create observation endpoint");
     let new_observation = PartialObservation {
         name: "Test Bird for Schema Capture".to_string(),

--- a/lib/clawspec-core/Cargo.toml
+++ b/lib/clawspec-core/Cargo.toml
@@ -64,6 +64,8 @@ wiremock = { workspace = true }
 # Force minimum versions for minimal-versions CI (annotate-snippets has incorrect anstyle dep)
 annotate-snippets = { workspace = true }
 anstyle = { workspace = true }
+# Force minimum version for minimal-versions CI (sharded-slab, via tracing-subscriber, needs lazy_static >=1.4)
+lazy_static = { workspace = true }
 
 [[bench]]
 name = "performance"

--- a/lib/clawspec-core/src/_tutorial/chapter_5.rs
+++ b/lib/clawspec-core/src/_tutorial/chapter_5.rs
@@ -55,7 +55,11 @@
 //! Document what responses mean:
 //!
 //! ```rust,no_run
+//! # // `with_response_description` requires the `redaction` feature; gate the example so
+//! # // `cargo test --doc` (default features) still compiles, and keep a no-op `main` for it.
+//! # #[cfg(feature = "redaction")]
 //! # use clawspec_core::ApiClient;
+//! # #[cfg(feature = "redaction")]
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let mut client = ApiClient::builder().build()?;
@@ -68,6 +72,8 @@
 //!     .await?;
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "redaction"))]
+//! # fn main() {}
 //! ```
 //!
 //! ## API Info Configuration
@@ -197,6 +203,9 @@
 //! #[derive(Deserialize, ToSchema)]
 //! struct ApiError { code: String, message: String }
 //!
+//! # // Uses `with_response_description` (redaction feature); gate so `cargo test --doc`
+//! # // with default features compiles, with a no-op `main` fallback for that case.
+//! # #[cfg(feature = "redaction")]
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Configure client with full metadata
@@ -239,6 +248,8 @@
 //! // println!("{}", spec.to_yaml()?);
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "redaction"))]
+//! # fn main() {}
 //! ```
 //!
 //! ## Key Points

--- a/lib/clawspec-core/src/client/openapi/schema.rs
+++ b/lib/clawspec-core/src/client/openapi/schema.rs
@@ -60,12 +60,30 @@ impl Debug for Schemas {
 
 impl Schemas {
     /// Folds nested `(name, schema)` pairs discovered via `ToSchema::schemas()` into the
-    /// name-keyed side table. First-write-wins: a name already present (either from an
+    /// name-keyed side table. First-write-wins: a name already present (for instance from an
     /// earlier nested walk, or destined to be shadowed by a directly registered type in
     /// `schema_vec`) is left untouched.
+    ///
+    /// When an already-present name maps to a *different* schema shape, the incoming one is a
+    /// genuine short-name collision between two distinct types (utoipa exposes only the name,
+    /// not a `TypeId`, for nested schemas, so they cannot be namespaced apart). The first is
+    /// kept and a warning is emitted, mirroring the nested-vs-registered path in `schema_vec`.
     fn absorb_nested(&mut self, nested: impl IntoIterator<Item = (String, RefOr<Schema>)>) {
         for (name, schema) in nested {
-            self.nested.entry(name).or_insert(schema);
+            match self.nested.entry(name) {
+                indexmap::map::Entry::Vacant(vacant) => {
+                    vacant.insert(schema);
+                }
+                indexmap::map::Entry::Occupied(occupied) if *occupied.get() != schema => {
+                    tracing::warn!(
+                        schema_name = %occupied.key(),
+                        "Two distinct nested types resolve to the same schema name with \
+                         different shapes; keeping the first. Disambiguate one of them with \
+                         #[schema(as = \"module::Type\")]."
+                    );
+                }
+                indexmap::map::Entry::Occupied(_) => {}
+            }
         }
     }
 
@@ -317,6 +335,11 @@ impl Schemas {
         // response and also used directly as another endpoint's body) - that's expected
         // and produces an identical schema body, so it's only worth a warning when the
         // bodies actually differ (a genuine short-name collision between distinct types).
+        //
+        // Keyed by the bare `name`, this map is only meaningful for names that occupy the
+        // bare slot in the output - i.e. `name_counts[name] == 1`. When several registered
+        // types share a short name they are emitted under namespaced names (`module_Foo`),
+        // so a same-named nested schema no longer collides and must be appended (see below).
         let registered_schemas: std::collections::HashMap<&str, &RefOr<Schema>> =
             non_primitive_entries
                 .iter()
@@ -333,9 +356,15 @@ impl Schemas {
 
         // Append schemas transitively discovered via nested ToSchema::schemas() walks.
         for (name, schema) in &self.nested {
+            // A directly-registered type only shadows this nested name when it actually
+            // occupies the bare slot in the output. If several registered types share the
+            // short name they are namespaced instead, leaving it free for the nested schema.
+            let shadows_bare_name = name_counts.get(name.as_str()).copied().unwrap_or(0) == 1;
             match registered_schemas.get(name.as_str()) {
-                Some(registered_schema) if *registered_schema == schema => continue,
-                Some(_) => {
+                Some(registered_schema) if shadows_bare_name && *registered_schema == schema => {
+                    continue;
+                }
+                Some(_) if shadows_bare_name => {
                     tracing::warn!(
                         schema_name = %name,
                         "Nested schema name collides with a directly registered schema of \
@@ -344,7 +373,7 @@ impl Schemas {
                     );
                     continue;
                 }
-                None => result.push((name.clone(), schema.clone())),
+                _ => result.push((name.clone(), schema.clone())),
             }
         }
 
@@ -634,6 +663,119 @@ mod tests {
         let schema_vec = schemas.schema_vec();
         let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
         assert_eq!(names, HashSet::from(["Node"]));
+    }
+
+    #[test]
+    fn test_schema_vec_nested_collision_keeps_registered_shape() {
+        // A directly-registered type and a distinct nested-only type share the same short
+        // schema name ("Config"). utoipa exposes only the name (no TypeId) for nested schemas,
+        // so they cannot be namespaced apart; the registered shape must win and the nested one
+        // is dropped (with a warning). A name-set assertion could not catch a wrong *shape*
+        // sneaking in under the right name, so this checks the emitted body and the count.
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Config {
+            timeout_ms: u64,
+        }
+
+        // Different type, same default short name ("Config"), reachable only as a nested field.
+        mod nested_mod {
+            use super::*;
+
+            #[derive(Debug, ToSchema, Serialize)]
+            pub struct Config {
+                retries: String,
+            }
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Root {
+            config: nested_mod::Config,
+        }
+
+        let mut schemas = Schemas::default();
+        schemas.add::<Config>();
+        schemas.add::<Root>();
+
+        let schema_vec = schemas.schema_vec();
+        let config_entries: Vec<_> = schema_vec
+            .iter()
+            .filter(|(name, _)| name == "Config")
+            .collect();
+        assert_eq!(
+            config_entries.len(),
+            1,
+            "the colliding short name must appear exactly once, got {schema_vec:?}"
+        );
+        assert_eq!(
+            &config_entries[0].1,
+            &<Config as utoipa::PartialSchema>::schema(),
+            "the directly-registered Config shape must take precedence over the nested one"
+        );
+    }
+
+    #[test]
+    fn test_schemas_merge_absorbs_nested_schemas() {
+        // `merge` must carry over the name-keyed nested table, not just the TypeId entries.
+        // Every other merge test uses primitive-only types, so this is the only coverage of
+        // schemas discovered transitively arriving through the merge path (e.g. complex
+        // struct-valued parameters).
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Leaf {
+            value: i32,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Mid {
+            leaf: Leaf,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Root {
+            mid: Mid,
+        }
+
+        let mut source = Schemas::default();
+        source.add::<Root>();
+
+        let mut target = Schemas::default();
+        target.merge(source);
+
+        let schema_vec = target.schema_vec();
+        let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(
+            names.is_superset(&HashSet::from(["Root", "Mid", "Leaf"])),
+            "merge must carry over transitively nested schemas, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_schema_vec_type_registered_and_nested_appears_once() {
+        // The common, benign case: the same Rust type is both registered directly and
+        // discovered as a nested field. It shares a TypeId, so both discoveries yield an
+        // identical shape; the nested duplicate must be dropped, leaving exactly one entry.
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Mid {
+            value: i32,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Root {
+            mid: Mid,
+        }
+
+        let mut schemas = Schemas::default();
+        schemas.add::<Root>();
+        schemas.add::<Mid>();
+
+        let mid_count = schemas
+            .schema_vec()
+            .iter()
+            .filter(|(name, _)| name == "Mid")
+            .count();
+        assert_eq!(
+            mid_count, 1,
+            "a type registered directly and discovered nested must appear exactly once"
+        );
     }
 
     #[test]

--- a/lib/clawspec-core/src/client/openapi/schema.rs
+++ b/lib/clawspec-core/src/client/openapi/schema.rs
@@ -40,6 +40,11 @@ where
 pub(in crate::client) struct Schemas {
     entries: IndexMap<TypeId, SchemaEntry>,
     resolved_names: std::collections::HashMap<TypeId, String>,
+    /// Schemas transitively reachable from a registered type's nested fields/variants,
+    /// discovered via utoipa's `ToSchema::schemas()` recursive walk. Keyed by name rather
+    /// than `TypeId` since utoipa's API only exposes the name for these. A `TypeId`-backed
+    /// entry with the same name always takes precedence (see `schema_vec`).
+    nested: IndexMap<String, RefOr<Schema>>,
 }
 
 impl Debug for Schemas {
@@ -54,8 +59,22 @@ impl Debug for Schemas {
 }
 
 impl Schemas {
-    pub(crate) fn add_entry(&mut self, entry: SchemaEntry) -> RefOr<Schema> {
+    /// Folds nested `(name, schema)` pairs discovered via `ToSchema::schemas()` into the
+    /// name-keyed side table. First-write-wins: a name already present (either from an
+    /// earlier nested walk, or destined to be shadowed by a directly registered type in
+    /// `schema_vec`) is left untouched.
+    fn absorb_nested(&mut self, nested: impl IntoIterator<Item = (String, RefOr<Schema>)>) {
+        for (name, schema) in nested {
+            self.nested.entry(name).or_insert(schema);
+        }
+    }
+
+    pub(crate) fn add_entry(&mut self, mut entry: SchemaEntry) -> RefOr<Schema> {
         let type_id = entry.id;
+
+        if !self.entries.contains_key(&type_id) {
+            self.absorb_nested(std::mem::take(&mut entry.nested));
+        }
 
         // First insert/update the entry
         let _ = self
@@ -80,7 +99,14 @@ impl Schemas {
         T: ToSchema + 'static,
     {
         let id = TypeId::of::<T>();
-        self.entries.entry(id).or_insert_with(SchemaEntry::of::<T>)
+        if !self.entries.contains_key(&id) {
+            let mut entry = SchemaEntry::of::<T>();
+            self.absorb_nested(std::mem::take(&mut entry.nested));
+            self.entries.insert(id, entry);
+        }
+        self.entries
+            .get_mut(&id)
+            .expect("entry inserted above if it was missing")
     }
 
     pub(in crate::client) fn add<T>(&mut self) -> RefOr<Schema>
@@ -265,6 +291,8 @@ impl Schemas {
                 }
             });
         }
+
+        self.absorb_nested(other.nested);
     }
 
     pub(in crate::client) fn schema_vec(&self) -> Vec<(String, RefOr<Schema>)> {
@@ -283,6 +311,18 @@ impl Schemas {
             *name_counts.entry(entry.name.clone()).or_insert(0) += 1;
         }
 
+        // Schemas already provided by a directly registered type; these take precedence
+        // over a same-named schema discovered only through a nested `schemas()` walk. The
+        // same Rust type commonly gets discovered both ways (e.g. it's nested in one
+        // response and also used directly as another endpoint's body) - that's expected
+        // and produces an identical schema body, so it's only worth a warning when the
+        // bodies actually differ (a genuine short-name collision between distinct types).
+        let registered_schemas: std::collections::HashMap<&str, &RefOr<Schema>> =
+            non_primitive_entries
+                .iter()
+                .map(|(_, entry)| (entry.name.as_str(), &entry.schema))
+                .collect();
+
         // Generate resolved names without cloning the entire structure
         for (type_id, entry) in non_primitive_entries {
             let resolved_name =
@@ -290,6 +330,24 @@ impl Schemas {
             let schema = entry.schema.clone();
             result.push((resolved_name, schema));
         }
+
+        // Append schemas transitively discovered via nested ToSchema::schemas() walks.
+        for (name, schema) in &self.nested {
+            match registered_schemas.get(name.as_str()) {
+                Some(registered_schema) if *registered_schema == schema => continue,
+                Some(_) => {
+                    tracing::warn!(
+                        schema_name = %name,
+                        "Nested schema name collides with a directly registered schema of \
+                         the same name but a different shape; keeping the directly \
+                         registered one."
+                    );
+                    continue;
+                }
+                None => result.push((name.clone(), schema.clone())),
+            }
+        }
+
         result
     }
 
@@ -362,6 +420,12 @@ pub(in crate::client) struct SchemaEntry {
     #[debug(ignore)]
     pub(in crate::client) schema: RefOr<Schema>,
     pub(in crate::client) examples: IndexSet<serde_json::Value>,
+    /// Schemas transitively reachable from this type's fields/variants, discovered via
+    /// utoipa's `ToSchema::schemas()` recursive walk. Only meaningful the first time this
+    /// entry is inserted into a `Schemas` collection; consumed there (see
+    /// `Schemas::absorb_nested`).
+    #[debug(ignore)]
+    pub(in crate::client) nested: Vec<(String, RefOr<Schema>)>,
 }
 
 impl SchemaEntry {
@@ -372,12 +436,15 @@ impl SchemaEntry {
         let id = TypeId::of::<T>();
         let name = T::name();
         let type_name = type_name::<T>();
+        let mut nested = Vec::new();
+        T::schemas(&mut nested);
         Self {
             id,
             type_name: type_name.to_string(),
             name: name.to_string(),
             schema: T::schema(),
             examples: IndexSet::default(),
+            nested,
         }
     }
 
@@ -407,6 +474,7 @@ impl SchemaEntry {
             name: name.to_string(),
             schema,
             examples: IndexSet::default(),
+            nested: Vec::new(),
         }
     }
 
@@ -452,6 +520,120 @@ mod tests {
         let schema_vec = schemas.schema_vec();
         assert_eq!(schema_vec.len(), 1);
         assert_eq!(schema_vec[0].0, "TestType");
+    }
+
+    #[test]
+    fn test_schemas_add_captures_nested_types_transitively() {
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Leaf {
+            value: i32,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Mid {
+            leaf: Leaf,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Root {
+            mid: Mid,
+        }
+
+        let mut schemas = Schemas::default();
+        // Only the root is registered directly; Mid and Leaf must be discovered via
+        // ToSchema::schemas()'s recursive walk.
+        schemas.add::<Root>();
+
+        let schema_vec = schemas.schema_vec();
+        let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(
+            names,
+            HashSet::from(["Root", "Mid", "Leaf"]),
+            "expected root and all transitively nested types to be captured"
+        );
+    }
+
+    #[test]
+    fn test_schemas_add_captures_flattened_nested_type() {
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Inner {
+            value: i32,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Outer {
+            #[serde(flatten)]
+            inner: Inner,
+            extra: String,
+        }
+
+        let mut schemas = Schemas::default();
+        schemas.add::<Outer>();
+
+        let schema_vec = schemas.schema_vec();
+        let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(
+            names.contains("Inner"),
+            "flattened nested type should still be captured, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_schemas_add_captures_enum_variant_payload_types() {
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Created {
+            id: u64,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Deleted {
+            id: u64,
+        }
+
+        #[derive(Debug, ToSchema, Serialize)]
+        enum Event {
+            Created(Created),
+            Deleted(Deleted),
+        }
+
+        // Constructed so the variants aren't flagged as dead code.
+        let _ = Event::Created(Created { id: 1 });
+        let _ = Event::Deleted(Deleted { id: 2 });
+
+        let mut schemas = Schemas::default();
+        schemas.add::<Event>();
+
+        let schema_vec = schemas.schema_vec();
+        let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(
+            names.contains("Created") && names.contains("Deleted"),
+            "enum variant payload types should be captured, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_schemas_add_terminates_on_recursive_type_with_no_recursion_attribute() {
+        // utoipa's own ToSchema::schemas() has no built-in cycle detection: a recursive
+        // field (directly or mutually recursive) *must* be annotated with
+        // `#[schema(no_recursion)]`, or utoipa itself stack-overflows while walking it -
+        // independent of clawspec-core, and identical to what `#[derive(OpenApi)]` +
+        // `components(schemas(...))` would do (see
+        // https://github.com/juhaku/utoipa/issues/1134). Document that requirement rather
+        // than working around it, since there's no way to intervene inside utoipa's opaque
+        // recursive call.
+        #[derive(Debug, ToSchema, Serialize)]
+        struct Node {
+            value: i32,
+            #[schema(no_recursion)]
+            next: Option<Box<Node>>,
+        }
+
+        let mut schemas = Schemas::default();
+        schemas.add::<Node>();
+
+        let schema_vec = schemas.schema_vec();
+        let names: HashSet<&str> = schema_vec.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(names, HashSet::from(["Node"]));
     }
 
     #[test]
@@ -840,6 +1022,7 @@ mod tests {
             name: "SimpleType".to_string(),
             schema: RefOr::T(utoipa::openapi::Schema::Object(Default::default())),
             examples: IndexSet::default(),
+            nested: Vec::new(),
         };
 
         // Add the same name from another "type" to force conflict
@@ -849,6 +1032,7 @@ mod tests {
             name: "SimpleType".to_string(), // Same name as above!
             schema: RefOr::T(utoipa::openapi::Schema::Object(Default::default())),
             examples: IndexSet::default(),
+            nested: Vec::new(),
         };
 
         schemas.entries.insert(simple_entry.id, simple_entry);

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -169,8 +169,13 @@
 //! Add descriptive text to your OpenAPI responses for better documentation:
 //!
 //! ```rust
+//! # // `with_response_description` requires the `redaction` feature; gate the example so
+//! # // `cargo test --doc` (default features) still compiles, while it is compile-checked
+//! # // under `--features redaction` / `--all-features`.
+//! # #[cfg(feature = "redaction")]
 //! use clawspec_core::ApiClient;
 //!
+//! # #[cfg(feature = "redaction")]
 //! # async fn example(client: &mut ApiClient) -> Result<(), Box<dyn std::error::Error>> {
 //! // Set a description for the actual returned status code
 //! client.get("/users/{id}")?
@@ -433,15 +438,16 @@
 //!
 //! ```rust
 //! use clawspec_core::{ApiClient, register_schemas};
-//! # use serde::{Serialize, Deserialize};
+//! # use serde::Deserialize;
 //! # use utoipa::ToSchema;
-//! # #[derive(Serialize, Deserialize, ToSchema)]
-//! # struct Address { street: String }
 //! # #[derive(Deserialize, ToSchema)]
-//! # struct ErrorResponse { code: String }
+//! # struct ApiError { code: String }
+//! # #[derive(Deserialize, ToSchema)]
+//! # struct ValidationError { field: String }
 //!
 //! # async fn example(client: &mut ApiClient) {
-//! register_schemas!(client, Address, ErrorResponse).await;
+//! // Error types never returned by an exercised endpoint — not statically reachable.
+//! register_schemas!(client, ApiError, ValidationError).await;
 //! # }
 //! ```
 //!
@@ -453,6 +459,13 @@
 //! something clawspec adds: the same care is needed with `#[derive(OpenApi)]`'s
 //! `components(schemas(...))`. Skipping it causes a stack overflow the first time the
 //! type is captured.
+//!
+//! **Collision diagnostics**: when two distinct types resolve to the same schema name with
+//! different shapes, clawspec keeps the first and emits a `tracing` warning at `WARN` — it
+//! never fails the run. These warnings only surface when a subscriber is installed; note that a
+//! `tracing-subscriber` configured with `.with_test_writer()` buffers output and shows it *only
+//! on test failure*, so a passing test that generates a spec will not display them. Resolve a
+//! reported collision by disambiguating one type with utoipa's `#[schema(as = "module::Type")]`.
 //!
 //! ## Error Handling
 //!
@@ -724,25 +737,27 @@ macro_rules! expected_status_codes {
 ///
 /// ```rust
 /// use clawspec_core::{ApiClient, register_schemas};
-/// use serde::{Serialize, Deserialize};
+/// use serde::Deserialize;
 /// use utoipa::ToSchema;
 ///
-/// #[derive(Serialize, Deserialize, ToSchema)]
-/// struct User {
-///     id: u64,
-///     name: String,
+/// // An error type never returned by any exercised endpoint.
+/// #[derive(Deserialize, ToSchema)]
+/// struct ApiError {
+///     code: String,
+///     message: String,
 /// }
 ///
+/// // A type only ever reached behind a `serde_json::Value` boundary.
 /// #[derive(Deserialize, ToSchema)]
-/// struct ErrorResponse {
-///     code: String,
+/// struct WebhookPayload {
+///     event: String,
 /// }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut client = ApiClient::builder().build()?;
 ///
-/// // Register multiple schemas at once
-/// register_schemas!(client, User, ErrorResponse).await;
+/// // Register multiple not-statically-reachable schemas at once.
+/// register_schemas!(client, ApiError, WebhookPayload).await;
 /// # Ok(())
 /// # }
 /// ```

--- a/lib/clawspec-core/src/lib.rs
+++ b/lib/clawspec-core/src/lib.rs
@@ -422,8 +422,14 @@
 //!
 //! ## Schema Registration
 //!
-//! Schemas are **automatically captured** when using `.json()` and `.as_json()` methods.
-//! For nested schemas or error types, use `register_schemas!`:
+//! Schemas are **automatically captured** when using `.json()` and `.as_json()` methods,
+//! including types nested inside them (fields, `Vec<T>`, `Option<T>`, enum variants, etc.
+//! that also derive `ToSchema`) — clawspec walks that graph for you via utoipa's own
+//! recursive schema collection.
+//!
+//! For types that aren't *statically* reachable through a `ToSchema`-deriving field —
+//! e.g. an error type only ever constructed dynamically, or a type behind a
+//! `serde_json::Value` field — use `register_schemas!` to add them explicitly:
 //!
 //! ```rust
 //! use clawspec_core::{ApiClient, register_schemas};
@@ -439,8 +445,14 @@
 //! # }
 //! ```
 //!
-//! **Note**: Nested schemas may not be fully resolved automatically. Register them explicitly
-//! if they're missing from your OpenAPI output.
+//! **Recursive types**: if a `ToSchema` type is directly or mutually recursive (e.g. a tree
+//! node holding `Option<Box<Self>>`, or `Pet` -> `Owner` -> `Pet`), the recursive field
+//! *must* be annotated with utoipa's own `#[schema(no_recursion)]` attribute. This is a
+//! requirement of utoipa's `ToSchema::schemas()` itself (it has no built-in cycle
+//! detection — see [utoipa#1134](https://github.com/juhaku/utoipa/issues/1134)), not
+//! something clawspec adds: the same care is needed with `#[derive(OpenApi)]`'s
+//! `components(schemas(...))`. Skipping it causes a stack overflow the first time the
+//! type is captured.
 //!
 //! ## Error Handling
 //!
@@ -698,18 +710,17 @@ macro_rules! expected_status_codes {
 ///
 /// # When to Use
 ///
-/// - **Nested Schemas**: When your JSON types contain nested structures that need to be fully resolved
-/// - **Error Types**: To ensure error response schemas are included in the OpenAPI specification
-/// - **Complex Dependencies**: When automatic schema capture doesn't include all referenced types
+/// Most JSON request/response schemas are captured automatically when using `.json()` and
+/// `.as_json()` methods — including types nested inside them (fields, `Vec<T>`, `Option<T>`,
+/// enum variants, etc. that also derive [`utoipa::ToSchema`]), since clawspec walks that graph
+/// for you. Use this macro only for types that aren't *statically* reachable through a
+/// `ToSchema`-deriving field, such as:
 ///
-/// # Automatic vs Manual Registration
-///
-/// Most JSON request/response schemas are captured automatically when using `.json()` and `.as_json()` methods.
-/// Use this macro when you need to ensure complete schema coverage, especially for nested types.
+/// - **Error Types**: An error response type never returned by any exercised endpoint
+/// - **Dynamic Types**: A type reached only through a `serde_json::Value` field or similar
+///   type-erased boundary
 ///
 /// # Examples
-///
-/// ## Basic Usage
 ///
 /// ```rust
 /// use clawspec_core::{ApiClient, register_schemas};
@@ -722,47 +733,16 @@ macro_rules! expected_status_codes {
 ///     name: String,
 /// }
 ///
-/// #[derive(Serialize, Deserialize, ToSchema)]
-/// struct Post {
-///     id: u64,
-///     title: String,
-///     author_id: u64,
+/// #[derive(Deserialize, ToSchema)]
+/// struct ErrorResponse {
+///     code: String,
 /// }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut client = ApiClient::builder().build()?;
 ///
 /// // Register multiple schemas at once
-/// register_schemas!(client, User, Post).await;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ## Nested Schemas
-///
-/// ```rust
-/// use clawspec_core::{ApiClient, register_schemas};
-/// use serde::{Serialize, Deserialize};
-/// use utoipa::ToSchema;
-///
-/// #[derive(Serialize, Deserialize, ToSchema)]
-/// struct Address {
-///     street: String,
-///     city: String,
-/// }
-///
-/// #[derive(Serialize, Deserialize, ToSchema)]
-/// struct User {
-///     id: u64,
-///     name: String,
-///     address: Address,  // Nested schema
-/// }
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut client = ApiClient::builder().build()?;
-///
-/// // Register both main and nested schemas for complete OpenAPI generation
-/// register_schemas!(client, User, Address).await;
+/// register_schemas!(client, User, ErrorResponse).await;
 /// # Ok(())
 /// # }
 /// ```

--- a/lib/clawspec-core/src/split/strategies.rs
+++ b/lib/clawspec-core/src/split/strategies.rs
@@ -78,7 +78,7 @@ impl SplitSchemasByTag {
         let mut schema_to_tags: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
 
         // Iterate through all paths and operations
-        for (_path, path_item) in spec.paths.paths.iter() {
+        for path_item in spec.paths.paths.values() {
             for operation in iter_operations(path_item) {
                 let tags = operation.tags.clone().unwrap_or_default();
                 if tags.is_empty() {


### PR DESCRIPTION
## Summary
- Wire in utoipa's own recursive `ToSchema::schemas()` so types nested inside a registered type (fields, `Vec<T>`, `Option<T>`, enum variants) are captured automatically, removing the need for manual `register_schemas!` calls per nested type.
- Directly registered types take precedence over same-named nested-only schemas so richer entries aren't clobbered.
- Recursive `ToSchema` types now require utoipa's `#[schema(no_recursion)]` attribute to avoid a stack overflow inside `ToSchema::schemas()` itself ([utoipa#1134](https://github.com/juhaku/utoipa/issues/1134)); documented in `lib.rs` since this is a new requirement surfaced by automatic nested capture.

## Review follow-up (hardening)
Addressed findings from a multi-agent PR review:
- **Silent-drop fix**: `absorb_nested` now emits an actionable `tracing::warn!` (pointing at `#[schema(as = "module::Type")]`) when two *distinct* nested-only types resolve to the same short name with different shapes, instead of dropping the second with no diagnostic. Keeps first-write-wins.
- **Bare-name collapse guard**: the nested-append loop in `schema_vec` only treats a nested name as shadowed when `name_counts == 1`, so a nested schema isn't wrongly suppressed when colliding registered types have been namespaced away from the bare-name slot.
- **Tests**: added collision/precedence tests that assert the emitted schema **body + count** (not just name-set membership) — different-shape collision keeps the registered shape, `merge` absorbs a non-empty nested table, and a type discovered both directly and nested appears exactly once.
- **Docs**: `register_schemas!` examples aligned with the "only for non-statically-reachable types" guidance; added a note that collision warnings are `tracing`-WARN-only and hidden by `.with_test_writer()` on passing tests; reworded the `LngLat` capture comment.
- **Doctest hardening**: the redaction-gated doc examples now compile under `cargo test --doc` with default features while staying compile-checked under `--features redaction` / `--all-features`.

_Note: name-keyed disambiguation via `TypeId`/suffix/path isn't possible downstream of utoipa — `ToSchema::schemas()` yields only `(name, schema)`, and the `$ref` to a nested type is baked into the parent schema body by utoipa using the bare name. The only lever that fixes both the component key and the embedded `$ref` is user-side `#[schema(as = "...")]`._

## Test plan
- [x] `cargo nextest run` (`clawspec-core` 550 passed, `axum-example` 37 passed)
- [x] `cargo test --doc` with and without `--features redaction`
- [x] `mise run check` (fmt + clippy/nextest/doctests `--all-features` + spectral) — clean
- [x] Updated `test_json_schema_capture.rs` and inline snapshot to cover automatic nested capture without explicit registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)