### PR TITLE
fix(ci): pin mise tool versions to stop flaky Setup Rust failures

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,10 +6,13 @@ GIT_CLIFF_OUTPUT = "CHANGELOG.md"
 experimental = true
 cargo = { binstall = true }
 
+# Pin exact versions: resolving "latest"/ranges forces a crates.io /versions
+# fetch (20s timeout) on every `mise install`, which intermittently times out
+# and fails the "Setup Rust environment" CI step.
 [tools]
-"cargo:cargo-audit" = "latest"
-"cargo:cargo-llvm-cov" = "latest"
-"cargo:cargo-nextest" = "0.9"
-"cargo:git-cliff" = "latest"
-"cargo:release-plz" = "latest"
+"cargo:cargo-audit" = "0.22.2"
+"cargo:cargo-llvm-cov" = "0.8.7"
+"cargo:cargo-nextest" = "0.9.140"
+"cargo:git-cliff" = "2.13.1"
+"cargo:release-plz" = "0.3.160"
 "npm:@stoplight/spectral-cli" = "6.16.0"


### PR DESCRIPTION
## Problem

Multiple CI jobs (MSRV, Code Quality, Beta) intermittently fail at the **"Setup Rust environment"** step. Root cause, confirmed from run [29636281670](https://github.com/ilaborie/clawspec/actions/runs/29636281670) logs:

The `setup-rust` composite action ends with `mise install`. `.mise.toml` pinned four cargo tools to `"latest"` (`cargo-audit`, `cargo-llvm-cov`, `git-cliff`, `release-plz`). Resolving `"latest"` forces mise to fetch `https://crates.io/api/v1/crates/<tool>/versions` with a **20s timeout** on every job. When crates.io is slow the fetch times out and `mise install` exits 1:

```
mise ERROR Failed to install tools: cargo:git-cliff@latest, cargo:release-plz@latest
  HTTP timed out after 20.00s for .../crates/git-cliff/versions
##[error] mise ... failed with exit code 1
```

`git-cliff` and `release-plz` aren't even used by CI — releases run through `release-plz/action@v0.5`, and `git-cliff` is a local changelog tool — yet every `mise install` resolves them.

## Fix

Pin every `[tools]` entry in `.mise.toml` to an exact version, so mise installs the tool directly and never performs the flaky `"latest"` remote-version lookup:

| Tool | Was | Now |
|------|-----|-----|
| `cargo-audit` | latest | 0.22.2 |
| `cargo-llvm-cov` | latest | 0.8.7 |
| `cargo-nextest` | 0.9 | 0.9.140 |
| `git-cliff` | latest | 2.13.1 |
| `release-plz` | latest | 0.3.160 |
| `spectral-cli` | 6.16.0 | 6.16.0 (unchanged) |

## Verification

- `mise install` locally resolves and installs all tools from prebuilt binaries with no `latest`/`/versions` lookup.
- `mise ls` shows each tool pinned to its exact version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
